### PR TITLE
Target .NET Framework 4.5.1 in generated csproj files

### DIFF
--- a/build/net45.txt
+++ b/build/net45.txt
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>{Name}</RootNamespace>
     <AssemblyName>{Name}</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <BaseIntermediateOutputPath>obj/net45</BaseIntermediateOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
There were some subtle changes to System.Data.dll in .NET Framework 4.5.1 that we need to take a dependency on. Specifically, some members went from abstract to virtual, and without this, we get unimplemented abstract member errors when compiling in Visual Studio.
