### PR TITLE
Default author is set in KoreBuild script

### DIFF
--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -13,6 +13,10 @@ default Configuration='Release'
 
 @{
   E("K_BUILD_VERSION", BuildNumber);
+  if (string.IsNullOrEmpty(E("K_AUTHOR")))
+  {
+    E("K_AUTHOR", AUTHORS);
+  }
 }
 
 #repo-initialize target='initialize'


### PR DESCRIPTION
- If there is a non-empty env var "K_AUTHOR", use its value as default
  author
- Otherwise, use the value of predefined var "AUTHORS"

parent #85 
