### PR TITLE
Use global node/npm/bower/grunt installs if available

### DIFF
--- a/build/_bower.shade
+++ b/build/_bower.shade
@@ -1,7 +1,7 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
 
-var bowerGloballyInstalled = '${TestCommand("bower --version")}'
+var bowerGloballyInstalled = '${TestCommand("bower", "--version")}'
 var bowerInstalled = '${Directory.Exists(Path.Combine(nodeDir, "node_modules", "bower"))}'
 var bowerCmd = '${ bowerGloballyInstalled ? "bower" : Path.Combine(nodeDir, "node_modules", "bower", "bin", "bower") }'
 
@@ -9,5 +9,5 @@ var bowerCmd = '${ bowerGloballyInstalled ? "bower" : Path.Combine(nodeDir, "nod
 npm npmCommand='install --prefix ${nodeDir} bower' if='!(bowerGloballyInstalled || bowerInstalled)' once='installBower'
 
 - // Run bower
-exec program='${bowerCmd}' commandline='${bowerCommand}' if='bowerGloballyInstalled'
+exec program='cmd' commandline='/C ${bowerCmd} ${bowerCommand}' workingdir='${bowerDir}' if='bowerGloballyInstalled'
 node nodeCommand='${bowerCmd} ${bowerCommand}' workingdir='${bowerDir}' if='!bowerGloballyInstalled'

--- a/build/_grunt.shade
+++ b/build/_grunt.shade
@@ -1,9 +1,13 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
+
+var gruntCliGloballyInstalled = '${TestCommand("grunt", "--version")}'
 var gruntCliInstalled = '${Directory.Exists(Path.Combine(nodeDir, "node_modules", "grunt-cli"))}'
+var gruntCmd = '${ gruntCliGloballyInstalled ? "grunt" : Path.Combine(nodeDir, "node_modules", "grunt-cli") }'
 
 -// Install grunt-cli locally
-npm npmCommand='install --prefix ${nodeDir} grunt-cli' if='!gruntCliInstalled' once='installGruntCli'
+npm npmCommand='install --prefix ${nodeDir} grunt-cli' if='!(gruntCliGloballyInstalled || gruntCliInstalled)' once='installGruntCli'
 
 -// Run grunt
-node nodeCommand='${Path.Combine(nodeDir, "node_modules", "grunt-cli", "bin", "grunt")}' workingdir='${gruntDir}'
+exec program='cmd' commandline='/C ${gruntCmd}' workingdir='${gruntDir}' if='gruntCliGloballyInstalled'
+node nodeCommand='${Path.Combine(nodeDir, "node_modules", "grunt-cli", "bin", "grunt")}' workingdir='${gruntDir}' if='!gruntCliGloballyInstalled'

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -115,29 +115,29 @@ functions @{
                       .Select(p => Path.GetDirectoryName(p))
                       .Distinct();
     }
-    bool TestCommand(string program, string commandline = null) {
+    bool TestCommand(string program, string commandline) {
       // Tests whether a given command succeeds at the command line.
       // Useful for testing whether a given command is installed and on the path, e.g. node
       var processStartInfo = new ProcessStartInfo {
         UseShellExecute = false,
-        WorkingDirectory = Directory.GetCurrentDirectory(),
-        FileName = program,
-        Arguments = commandline,
+        FileName = "cmd",
+        Arguments = "/C " + program + " " + commandline,
       };
       try {
         Log.Info(string.Format("Testing for command: {0} {1}", program, commandline));
         var process = Process.Start(processStartInfo);
         process.WaitForExit();
         if (process.ExitCode == 0) {
-          Log.Info("   command found");
+          Log.Info("   command found (0 exit code)");
           return true;
         }
         else {
-          Log.Warn("   command not found");
+          Log.Warn("   command not found (non-0 exit code)");
           return false;
         }
       }
-      catch (Exception) {
+      catch (Exception ex) {
+        Log.Warn("   command exception: " + ex.ToString());
         Log.Warn("   command not found");
         return false;
       }

--- a/build/_node-install.shade
+++ b/build/_node-install.shade
@@ -10,7 +10,7 @@ default nodeVer = '0.10.28'
 default npmVer = '1.4.9'
 default nodeExeSha = '628FFD6C3577068C00CEC9F6F897F0EC8F5212D9'
 default nodeInstallDir = '${Path.Combine(binDir, "nodejs")}'
-default nodeGloballyInstalled = '${TestCommand("node --version")}'
+default nodeGloballyInstalled = '${TestCommand("node" , "--version")}'
 
 var nodeExe = 'node.exe'
 var npmZip = 'npm-${npmVer}.zip'

--- a/build/_node.shade
+++ b/build/_node.shade
@@ -1,6 +1,6 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "node")}'
-default nodeGloballyInstalled = '${TestCommand("node --version")}'
+default nodeGloballyInstalled = '${TestCommand("node", "--version")}'
 
 var nodeExePath = '${ nodeGloballyInstalled ? "node" : Path.Combine(nodeDir, "node.exe") }'
 

--- a/build/_npm.shade
+++ b/build/_npm.shade
@@ -2,8 +2,8 @@ default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
 default npmDir = '${currentDir}'
 
-var npmGloballyInstalled = '${TestCommand("npm --version")}'
+var npmGloballyInstalled = '${TestCommand("npm" , "--version")}'
 var npmCmd = '${ npmGloballyInstalled ? "npm" : Path.Combine(nodeDir, "npm.cmd") }'
 
 node-install once='installNode'
-exec program='${npmCmd}' commandline='${npmCommand}' workingdir='${npmDir}'
+exec program='cmd' commandline='/C ${npmCmd} ${npmCommand}' workingdir='${npmDir}'


### PR DESCRIPTION
Change the shade tasks that install/run node, npm, bower and grunt to use global install if already available, avoiding the local install. Also fixes the issue of the local install happening every time even if it's already there.
