### PR TITLE
Build samples

### DIFF
--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -78,6 +78,9 @@ default Configuration='${E("Configuration")}'
 #xunit-test target='test' if='Directory.Exists("test")'
   k-test each='var projectFile in Files.Include("test/**/project.json")'
 
+#build-samples target='test'
+  k-build each='var projectFile in Files.Include("samples/**/project.json")' configuration='${Configuration}'
+
 #make-roslyn-fast
   ngen-roslyn
 


### PR DESCRIPTION
#96 - Build samples during normal compilation to make sure they stay up to date. This is especially a problem for Entropy.
