### PR TITLE
Updated the grunt target to delete node_modules directory afterward

### DIFF
--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -106,7 +106,13 @@ default Configuration='${E("Configuration")}'
   -// Find all dirs that contain a gruntfile.js file
   var gruntDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "gruntfile.js")}'
   grunt each='var gruntDir in gruntDirs'
-  
+  -CallTarget("clean-npm-modules");
+ 
+#clean-npm-modules
+  -// Find all dirs that contain a package.json file
+  var npmDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "package.json")}'
+  exec program='cmd' commandline='/C rmdir /S /Q ${Path.Combine(dir, "node_modules")}' each='var dir in npmDirs' if='Directory.Exists(Path.Combine(dir, "node_modules"))'
+
 #stylecop
   stylecop-setup
   stylecop-run each='var projectFile in Files.Include("src/**/project.json")'

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -106,16 +106,12 @@ default Configuration='${E("Configuration")}'
   -// Find all dirs that contain a gruntfile.js file
   var gruntDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "gruntfile.js")}'
   grunt each='var gruntDir in gruntDirs'
-  @{
-  	if (!IsMono) {
-  	  CallTarget("clean-npm-modules");
-  	}
-  }
+  -CallTarget("clean-npm-modules");
  
-#clean-npm-modules
+#clean-npm-modules if='!IsMono'
   -// Find all dirs that contain a package.json file
-  var npmDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "package.json")}'
-  exec program='cmd' commandline='/C rmdir /S /Q ${Path.Combine(dir, "node_modules")}' each='var dir in npmDirs' if='Directory.Exists(Path.Combine(dir, "node_modules"))'
+  var npmDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "package.json").Select(d => Path.Combine(d, "node_modules"))}'
+  robocopy-delete dir='${npmDir}' each='var npmDir in npmDirs'
 
 #stylecop
   stylecop-setup

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -106,7 +106,11 @@ default Configuration='${E("Configuration")}'
   -// Find all dirs that contain a gruntfile.js file
   var gruntDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "gruntfile.js")}'
   grunt each='var gruntDir in gruntDirs'
-  -CallTarget("clean-npm-modules");
+  @{
+  	if (!IsMono) {
+  	  CallTarget("clean-npm-modules");
+  	}
+  }
  
 #clean-npm-modules
   -// Find all dirs that contain a package.json file

--- a/build/_robocopy-delete.shade
+++ b/build/_robocopy-delete.shade
@@ -1,8 +1,29 @@
 -// Deletes a directory using robocopy such that long paths aren't an issue
 default parentDir = '${Directory.GetParent(dir).FullName}'
 default tempDir = '${Path.Combine(parentDir, "__emp_dir")}'
+default logFile = '${Path.Combine(parentDir, "robocopy-log.txt")}'
 
 exec program='cmd' commandline='/C mkdir ${tempDir}'
-exec program='cmd' commandline='/C robocopy ${tempDir} ${dir} /mir'
+
+@{
+    var robocopyProcessStartInfo = new ProcessStartInfo {
+        UseShellExecute = false,
+        WorkingDirectory = dir,
+        FileName = "cmd",
+        Arguments = "/C robocopy " + tempDir + " " + dir + " /PURGE /NS /NC /NP /NFL /NDL /NJH /NJS /LOG:" + logFile,
+    };
+
+    var robocopyProcess = Process.Start(robocopyProcessStartInfo);
+    robocopyProcess.WaitForExit();
+
+    // Robocopy encodes results as a bitmap in the return code, see http://ss64.com/nt/robocopy-exit.html
+    if (robocopyProcess.ExitCode >= 16)
+    {
+        throw new Exception(string.Format("Error {0} attempting to delete {1}, see {2} for more details", robocopyProcess.ExitCode, dir, logFile));
+    }
+}
+-//exec program='cmd' commandline='/C robocopy ${tempDir} ${dir} /PURGE /NS /NC /NP /NFL /NDL /NJH /NJS /LOG:${logFile}'
+
 exec program='cmd' commandline='/C rmdir ${tempDir}'
 exec program='cmd' commandline='/C rmdir ${dir}'
+exec program='cmd' commandline='/C del ${logFile}'

--- a/build/_robocopy-delete.shade
+++ b/build/_robocopy-delete.shade
@@ -1,0 +1,8 @@
+-// Deletes a directory using robocopy such that long paths aren't an issue
+default parentDir = '${Directory.GetParent(dir).FullName}'
+default tempDir = '${Path.Combine(parentDir, "__emp_dir")}'
+
+exec program='cmd' commandline='/C mkdir ${tempDir}'
+exec program='cmd' commandline='/C robocopy ${tempDir} ${dir} /mir'
+exec program='cmd' commandline='/C rmdir ${tempDir}'
+exec program='cmd' commandline='/C rmdir ${dir}'


### PR DESCRIPTION
- It shells out to "rmdir" tool as that is safe for long paths
- Doing this to work around the issue with KRE compile failing when long paths are present in the project folder