### PR TITLE
Get build and restore options from environment; provide --quiet target

### DIFF
--- a/build/_k-build.shade
+++ b/build/_k-build.shade
@@ -1,9 +1,9 @@
 @{/*
 
-k-build 
+k-build
     Builds project. Downloads and executes k sdk tools.
 
-projectFile='' 
+projectFile=''
     Required. Path to the project.json to build.
 
 configuration=''
@@ -11,7 +11,7 @@ configuration=''
 */}
 
 default configuration = 'debug'
-default build_options='${E("K_build_options")}'
+default build_options='${E("KPM_build_options")}'
 var projectFolder='${Path.GetDirectoryName(projectFile)}'
 var projectName='${Path.GetFileName(projectFolder)}'
 var projectBin='${Path.Combine(projectFolder, "bin", configuration)}'

--- a/build/_k-restore.shade
+++ b/build/_k-restore.shade
@@ -1,10 +1,10 @@
 @{/*
 
-k-restore 
+k-restore
     Restores nuget packages required for k projects. Downloads and executes k sdk tools.
 */}
 
-default restore_options='${E("K_build_options")}'
+default restore_options='${E("KPM_restore_options")}'
 
 exec program='cmd' commandline='/C kpm restore${restore_options}' if='!IsMono'
 exec program='kpm' commandline='restore${restore_options}' if='IsMono'

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -118,10 +118,10 @@ default Configuration='${E("Configuration")}'
   var npmDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "package.json").Select(d => Path.Combine(d, "node_modules"))}'
   robocopy-delete dir='${npmDir}' each='var npmDir in npmDirs'
 
-#set-quiet
+#--quiet
   @{
-    E("K_build_options"," --quiet");
-    E("K_restore_options"," --quiet");
+    E("KPM_build_options"," --quiet");
+    E("KPM_restore_options"," --quiet");
   }
 
 #stylecop


### PR DESCRIPTION
- see #123
- leaves default build (just `build`) unchanged
- run `build --quiet default` for a much-quieter build
