### PR TITLE
Skip calling clean-npm-modules from #run-grunt on Mono

### DIFF
--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -106,7 +106,12 @@ default Configuration='${E("Configuration")}'
   -// Find all dirs that contain a gruntfile.js file
   var gruntDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "gruntfile.js")}'
   grunt each='var gruntDir in gruntDirs'
-  -CallTarget("clean-npm-modules");
+  @{
+      if (!IsMono)
+      {
+           CallTarget("clean-npm-modules");
+      }
+  }
  
 #clean-npm-modules if='!IsMono'
   -// Find all dirs that contain a package.json file


### PR DESCRIPTION
@DamianEdwards The original target will fail on Mono since the `#clean-npm-modules` is skipped.
