### PR TITLE
Fix #118, Only check K projects for XML documentation errors

### DIFF
--- a/build/_k-xml-docs-test.shade
+++ b/build/_k-xml-docs-test.shade
@@ -8,41 +8,48 @@ default BASE_DIR='${Directory.GetCurrentDirectory()}'
 
 @{
     var srcDir = Path.Combine(BASE_DIR, "src");
-    foreach (var xmlFilePath in Files.Include(Path.Combine(srcDir, "**/*.xml")))
+    foreach (var projectFile in Files.Include(Path.Combine(srcDir, "**", "project.json")))
     {
-        var errors = 0;
-        var xmlLines = File.ReadAllLines(xmlFilePath);
-        for (var linesIndex = 0; linesIndex < xmlLines.Length; ++linesIndex)
+        var binDirectory = Path.Combine(Path.GetDirectoryName(projectFile), "bin");
+        if (Directory.Exists(binDirectory))
         {
-            var xmlLine = xmlLines[linesIndex].Trim();
-            if (xmlLine.StartsWith("<!--"))
+            foreach (var xmlFilePath in Files.Include(Path.Combine(binDirectory, "**", "*.xml")))
             {
-                // Compiler only emits comments for syntax errors.
-                if (errors == 0)
+                var errors = 0;
+                var xmlLines = File.ReadAllLines(xmlFilePath);
+                for (var linesIndex = 0; linesIndex < xmlLines.Length; linesIndex++)
                 {
-                    Log.Warn(string.Format("Invalid documentation syntax in {0}:", xmlFilePath));
+                    var xmlLine = xmlLines[linesIndex].Trim();
+                    if (xmlLine.StartsWith("<!--"))
+                    {
+                        // Compiler only emits comments for syntax errors.
+                        if (errors == 0)
+                        {
+                            Log.Warn(string.Format("Invalid documentation syntax in {0}:", xmlFilePath));
+                        }
+
+                        errors++;
+                        Log.Warn(string.Format("  {0}: {1}", linesIndex + 1, xmlLine));
+                    }
+                    else if (xmlLine.Contains("\"!:"))
+                    {
+                        // '!' is reference string error token.
+                        if (errors == 0)
+                        {
+                            Log.Warn(string.Format("Invalid documentation syntax in {0}:", xmlFilePath));
+                        }
+
+                        errors++;
+                        Log.Warn(string.Format("  {0}: {1}", linesIndex + 1, xmlLine));
+                    }
                 }
 
-                ++errors;
-                Log.Warn(string.Format("  {0}: {1}", linesIndex + 1, xmlLine));
-            }
-            else if (xmlLine.Contains("\"!:"))
-            {
-                // '!' is reference string error token.
-                if (errors == 0)
+                if (errors != 0)
                 {
-                    Log.Warn(string.Format("Invalid documentation syntax in {0}:", xmlFilePath));
+                    Environment.Exit(errors);
+                    return;
                 }
-
-                ++errors;
-                Log.Warn(string.Format("  {0}: {1}", linesIndex + 1, xmlLine));
             }
-        }
-
-        if (errors != 0)
-        {
-            Environment.Exit(errors);
-            return;
         }
     }
 }


### PR DESCRIPTION
- ignore leftover XML files e.g. from other branches
  - tested manually in MVC repo with a bad doc file outside a K project
- align with clean target: that only removes bin directories under K projects
- approach ignores XML files in .csproj projects but no such projects in
  repos where _k-xml-docs-test.shade file is used

Address old [comment](https://github.com/aspnet/Universe/pull/101/files#r16633938) from @Eilon on PR#101

> Traditionally we use i++ and not ++i.
