### PR TITLE
Fix the casing of the configuration

### DIFF
--- a/build/_k-build.shade
+++ b/build/_k-build.shade
@@ -7,10 +7,10 @@ projectFile=''
     Required. Path to the project.json to build.
 
 configuration=''
-    Optional. The configuration to build in. Defaults to 'debug'.
+    Optional. The configuration to build in. Defaults to 'Debug'.
 */}
 
-default configuration = 'debug'
+default configuration = 'Debug'
 default build_options='${E("KPM_build_options")}'
 var projectFolder='${Path.GetDirectoryName(projectFile)}'
 var projectName='${Path.GetFileName(projectFolder)}'

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -22,7 +22,7 @@ default Configuration='${E("Configuration")}'
   }
   if (string.IsNullOrEmpty(Configuration))
   {
-    Configuration = "debug";
+    Configuration = "Debug";
     E("Configuration", Configuration);
   }
 }


### PR DESCRIPTION
Under Linux building KRuntime a second time fails with 
```
Copy From: [...]/src/klr.host/bin/Debug/aspnet50/*.*
       To: [...]/src/klr.host/../../artifacts/build/KRE-CLR-x86/bin
cp: cannot stat '[...]/src/klr.host/bin/Debug/aspnet50/*.*': No such file or directory
```

There is a `bin/debug` folder though.