### PR TITLE
React to renaming "kpm build" to "kpm pack"

### DIFF
--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -37,7 +37,7 @@ default Configuration='${E("Configuration")}'
   k-clean each='var projectFile in Files.Include("src/**/project.json")'
 
 #build-compile target='compile' if='Directory.Exists("src")'
-  k-build each='var projectFile in Files.Include("src/**/project.json")' configuration='${Configuration}'
+  kpm-pack each='var projectFile in Files.Include("src/**/project.json")' configuration='${Configuration}'
   @{
     foreach (var nupkg in Files.Include(Path.Combine(BUILD_DIR, "*/*.nupkg")))
     {
@@ -79,7 +79,7 @@ default Configuration='${E("Configuration")}'
   k-test each='var projectFile in Files.Include("test/**/project.json")'
 
 #build-samples target='test' if='Directory.Exists("samples")'
-  k-build each='var projectFile in Files.Include("samples/**/project.json")' configuration='${Configuration}'
+  kpm-pack each='var projectFile in Files.Include("samples/**/project.json")' configuration='${Configuration}'
 
 #make-roslyn-fast
   ngen-roslyn
@@ -120,7 +120,7 @@ default Configuration='${E("Configuration")}'
 
 #--quiet
   @{
-    E("KPM_build_options"," --quiet");
+    E("KPM_pack_options"," --quiet");
     E("KPM_restore_options"," --quiet");
   }
 

--- a/build/_kpm-pack.shade
+++ b/build/_kpm-pack.shade
@@ -1,7 +1,7 @@
 @{/*
 
-k-build
-    Builds project. Downloads and executes k sdk tools.
+kpm-pack
+    Builds package from project. Downloads and executes k sdk tools.
 
 projectFile=''
     Required. Path to the project.json to build.
@@ -11,12 +11,12 @@ configuration=''
 */}
 
 default configuration = 'Debug'
-default build_options='${E("KPM_build_options")}'
+default pack_options='${E("KPM_pack_options")}'
 var projectFolder='${Path.GetDirectoryName(projectFile)}'
 var projectName='${Path.GetFileName(projectFolder)}'
 var projectBin='${Path.Combine(projectFolder, "bin", configuration)}'
 
 directory delete="${projectBin}"
-exec program='cmd' commandline='/C kpm build${build_options} ${projectFolder} --configuration ${configuration}' if='!IsMono'
-exec program='kpm' commandline='build${build_options} ${projectFolder} --configuration ${configuration}' if='IsMono'
+exec program='cmd' commandline='/C kpm pack${pack_options} ${projectFolder} --configuration ${configuration}' if='!IsMono'
+exec program='kpm' commandline='pack${pack_options} ${projectFolder} --configuration ${configuration}' if='IsMono'
 copy sourceDir='${projectBin}' outputDir='${Path.Combine(BUILD_DIR, projectName)}'


### PR DESCRIPTION
parent: https://github.com/aspnet/XRE/issues/967

@davidfowl , I keep the `k-build` goal and add a new goal `k-pack`. `k-build` invokes `kpm build`, while `k-pack` invokes `kpm pack`.

Tested this change by doing `build verify` in this branch https://github.com/aspnet/XRE/pull/1124