### PR TITLE
Fix for test hang issue

### DIFF
--- a/build/_k-test.shade
+++ b/build/_k-test.shade
@@ -40,7 +40,11 @@ projectFile=''
         
         foreach (var framework in targetFrameworks)
         {
-            if (framework.StartsWith("net", StringComparison.OrdinalIgnoreCase)
+            if(IsMono)
+            {
+                K("test -parallel none", projectFolder, "");
+            } 
+            else if (framework.StartsWith("net", StringComparison.OrdinalIgnoreCase)
                 || (framework.StartsWith("aspnet", StringComparison.OrdinalIgnoreCase)
                     && !framework.StartsWith("aspnetcore", StringComparison.OrdinalIgnoreCase)))
             {

--- a/build/_k-test.shade
+++ b/build/_k-test.shade
@@ -40,15 +40,13 @@ projectFile=''
         
         foreach (var framework in targetFrameworks)
         {
-            if(IsMono)
-            {
-                K("test -parallel none", projectFolder, "");
-            } 
-            else if (framework.StartsWith("net", StringComparison.OrdinalIgnoreCase)
+            var testArgs = IsMono ? " -parallel none" : "";
+
+            if (framework.StartsWith("net", StringComparison.OrdinalIgnoreCase)
                 || (framework.StartsWith("aspnet", StringComparison.OrdinalIgnoreCase)
                     && !framework.StartsWith("aspnetcore", StringComparison.OrdinalIgnoreCase)))
             {
-                K("test", projectFolder, "");
+                K(("test" + testArgs), projectFolder, "");
             }
             else if (!IsMono)
             {


### PR DESCRIPTION
@pranavkm 
Running `k test` on mono does not return the control to the shell due to an issue with xunit. Passing the `-parallel none` flag seems to fix the issue.Adding this to Korebuild so that we can have musicstore passing on Linux and Mac on CI