### PR TITLE
Quiet builds a bit more

### DIFF
--- a/build/_bower.shade
+++ b/build/_bower.shade
@@ -6,7 +6,7 @@ var bowerInstalled = '${Directory.Exists(Path.Combine(nodeDir, "node_modules", "
 var bowerCmd = '${ bowerGloballyInstalled ? "bower" : Path.Combine(nodeDir, "node_modules", "bower", "bin", "bower") }'
 
 - // Install bower locally if not already installed either globally or locally
-npm npmCommand='install --prefix ${nodeDir} bower' if='!(bowerGloballyInstalled || bowerInstalled)' once='installBower'
+npm npmCommand='install ${E("npm_install_options")} --prefix ${nodeDir} bower' if='!(bowerGloballyInstalled || bowerInstalled)' once='installBower'
 
 - // Run bower
 exec program='cmd' commandline='/C ${bowerCmd} ${bowerCommand}' workingdir='${bowerDir}' if='bowerGloballyInstalled && !IsLinux'

--- a/build/_bower.shade
+++ b/build/_bower.shade
@@ -1,8 +1,8 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
 
-var bowerGloballyInstalled = '${TestCommand("bower", "--version")}'
 var bowerInstalled = '${Directory.Exists(Path.Combine(nodeDir, "node_modules", "bower"))}'
+var bowerGloballyInstalled = '${ !bowerInstalled && TestCommand("bower", "--version") }'
 var bowerCmd = '${ bowerGloballyInstalled ? "bower" : Path.Combine(nodeDir, "node_modules", "bower", "bin", "bower") }'
 
 - // Install bower locally if not already installed either globally or locally

--- a/build/_grunt.shade
+++ b/build/_grunt.shade
@@ -1,8 +1,8 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
 
-var gruntCliGloballyInstalled = '${TestCommand("grunt", "--version")}'
 var gruntCliInstalled = '${Directory.Exists(Path.Combine(nodeDir, "node_modules", "grunt-cli"))}'
+var gruntCliGloballyInstalled = '${ !gruntCliInstalled && TestCommand("grunt", "--version") }'
 var gruntCmd = '${ gruntCliGloballyInstalled ? "grunt" : Path.Combine(nodeDir, "node_modules", "grunt-cli") }'
 
 -// Install grunt-cli locally

--- a/build/_grunt.shade
+++ b/build/_grunt.shade
@@ -6,7 +6,7 @@ var gruntCliInstalled = '${Directory.Exists(Path.Combine(nodeDir, "node_modules"
 var gruntCmd = '${ gruntCliGloballyInstalled ? "grunt" : Path.Combine(nodeDir, "node_modules", "grunt-cli") }'
 
 -// Install grunt-cli locally
-npm npmCommand='install --prefix ${nodeDir} grunt-cli' if='!(gruntCliGloballyInstalled || gruntCliInstalled)' once='installGruntCli'
+npm npmCommand='install ${E("npm_install_options")} --prefix ${nodeDir} grunt-cli' if='!(gruntCliGloballyInstalled || gruntCliInstalled)' once='installGruntCli'
 
 -// Run grunt
 exec program='cmd' commandline='/C ${gruntCmd}' workingdir='${gruntDir}' if='gruntCliGloballyInstalled'

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -95,12 +95,12 @@ default Configuration='${E("Configuration")}'
 #restore-npm-modules
   -// Find all dirs that contain a package.json file
   var npmDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "package.json")}'
-  npm npmCommand='install' each='var npmDir in npmDirs'
+  npm npmCommand='install ${E("npm_install_options")}' each='var npmDir in npmDirs'
 
 #restore-bower-components
   -// Find all dirs that contain a bower.json file
   var bowerDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "bower.json")}'
-  bower each='var bowerDir in bowerDirs' bowerCommand='install'
+  bower each='var bowerDir in bowerDirs' bowerCommand='install ${E("bower_install_options")}'
 
 #run-grunt .restore-npm-modules .restore-bower-components target='compile'
   -// Find all dirs that contain a gruntfile.js file
@@ -122,6 +122,8 @@ default Configuration='${E("Configuration")}'
   @{
     E("KPM_pack_options"," --quiet");
     E("KPM_restore_options"," --quiet");
+    E("bower_install_options","--quiet");
+    E("npm_install_options","--quiet");
   }
 
 #stylecop if='Directory.Exists("src")'

--- a/build/_node-install.shade
+++ b/build/_node-install.shade
@@ -10,7 +10,7 @@ default nodeVer = '0.10.28'
 default npmVer = '1.4.9'
 default nodeExeSha = '628FFD6C3577068C00CEC9F6F897F0EC8F5212D9'
 default nodeInstallDir = '${Path.Combine(binDir, "nodejs")}'
-default nodeGloballyInstalled = '${TestCommand("node" , "--version")}'
+default nodeGloballyInstalled = '${ !Directory.Exists(nodeInstallDir) && TestCommand("node" , "--version") }'
 
 var nodeExe = 'node.exe'
 var npmZip = 'npm-${npmVer}.zip'

--- a/build/_node.shade
+++ b/build/_node.shade
@@ -1,8 +1,9 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "node")}'
-default nodeGloballyInstalled = '${TestCommand("node", "--version")}'
-
-var nodeExePath = '${ nodeGloballyInstalled ? "node" : Path.Combine(nodeDir, "node.exe") }'
 
 node-install once='installNode'
+
+var nodeExeFile = '${ Path.Combine(nodeDir, "node.exe") }'
+var nodeExePath = '${ File.Exists(nodeExeFile) ? nodeExeFile : "node"  }'
+
 exec program='${nodeExePath}' commandline='${nodeCommand}'

--- a/build/_npm.shade
+++ b/build/_npm.shade
@@ -2,9 +2,10 @@ default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
 default npmDir = '${currentDir}'
 
-var npmGloballyInstalled = '${TestCommand("npm" , "--version")}'
-var npmCmd = '${ npmGloballyInstalled ? "npm" : Path.Combine(nodeDir, "npm.cmd") }'
-
 node-install once='installNode'
+
+var npmFile = '${ Path.Combine(nodeDir, "npm.cmd") }'
+var npmCmd = '${ File.Exists(npmFile) ? npmFile : "npm" }'
+
 exec program='cmd' commandline='/C ${npmCmd} ${npmCommand}' workingdir='${npmDir}' if='!IsLinux'
 exec program='${npmCmd}' commandline='${npmCommand}' workingdir='${npmDir}' if='IsLinux'


### PR DESCRIPTION
As the commits say:
- include `bower` and `npm` commands in `--quiet` target
- short-circuit `TestCommand()` calls once commands are installed locally

/cc @davidfowl 