### PR TITLE
Create target directory for `npm` installations

### DIFF
--- a/build/_node-install.shade
+++ b/build/_node-install.shade
@@ -10,16 +10,16 @@ default nodeVer = '0.10.28'
 default npmVer = '1.4.9'
 default nodeExeSha = '628FFD6C3577068C00CEC9F6F897F0EC8F5212D9'
 default nodeInstallDir = '${Path.Combine(binDir, "nodejs")}'
-default nodeGloballyInstalled = '${ !Directory.Exists(nodeInstallDir) && TestCommand("node" , "--version") }'
 
 var nodeExe = 'node.exe'
 var npmZip = 'npm-${npmVer}.zip'
 var nodeDist = 'http://nodejs.org/dist/'
 var nodeUrl = '${nodeDist}v${nodeVer}/${nodeExe}'
 var npmUrl = '${nodeDist}npm/${npmZip}'
-var doInstall = '${!nodeGloballyInstalled && !Directory.Exists(nodeInstallDir)}'
 var nodeInstallExePath = '${Path.Combine(nodeInstallDir, nodeExe)}'
 var npmInstallZipPath = '${Path.Combine(nodeInstallDir, npmZip)}'
+
+var doInstall = '${ !File.Exists(nodeInstallExePath) && !TestCommand("node", "--version") }'
 
 @{
   if (doInstall) {

--- a/build/_npm.shade
+++ b/build/_npm.shade
@@ -7,5 +7,10 @@ node-install once='installNode'
 var npmFile = '${ Path.Combine(nodeDir, "npm.cmd") }'
 var npmCmd = '${ File.Exists(npmFile) ? npmFile : "npm" }'
 
+- // Ensure nodeDir exists. npmCommand is likely a package installation targeting that directory.
+@{
+  Directory.CreateDirectory(nodeDir);
+}
+
 exec program='cmd' commandline='/C ${npmCmd} ${npmCommand}' workingdir='${npmDir}' if='!IsLinux'
 exec program='${npmCmd}' commandline='${npmCommand}' workingdir='${npmDir}' if='IsLinux'


### PR DESCRIPTION
- #144
- problems seem primarily to occur when `node` is globally installed but a
  package (`grunt` or `bower`) is not; `npm install X` fails in this case
- create the `--prefix` directory first to avoid these installation failures