### PR TITLE
Make `bower`, `grunt`, and `npm` commands a bit faster and more reliable

### DIFF
--- a/build/_bower.shade
+++ b/build/_bower.shade
@@ -1,11 +1,12 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
 
-var bowerInstalled = '${Directory.Exists(Path.Combine(nodeDir, "node_modules", "bower"))}'
+var bowerLibrary = '${ Path.Combine(nodeDir, "node_modules", "bower", "bin", "bower") }'
+var bowerInstalled = '${ File.Exists(bowerLibrary) }'
 var bowerGloballyInstalled = '${ !bowerInstalled && TestCommand("bower", "--version") }'
-var bowerCmd = '${ bowerGloballyInstalled ? "bower" : Path.Combine(nodeDir, "node_modules", "bower", "bin", "bower") }'
+var bowerCmd = '${ bowerGloballyInstalled ? "bower" : bowerLibrary }'
 
-- // Install bower locally if not already installed either globally or locally
+- // Install bower locally if not already installed either globally or locally; creates bowerLibrary file if run
 npm npmCommand='install ${E("npm_install_options")} --prefix ${nodeDir} bower' if='!(bowerGloballyInstalled || bowerInstalled)' once='installBower'
 
 - // Run bower

--- a/build/_bower.shade
+++ b/build/_bower.shade
@@ -1,9 +1,9 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
-
 var bowerLibrary = '${ Path.Combine(nodeDir, "node_modules", "bower", "bin", "bower") }'
 var bowerInstalled = '${ File.Exists(bowerLibrary) }'
-var bowerGloballyInstalled = '${ !bowerInstalled && TestCommand("bower", "--version") }'
+
+default bowerGloballyInstalled = '${ !bowerInstalled && TestCommand("bower", "--version") }'
 var bowerCmd = '${ bowerGloballyInstalled ? "bower" : bowerLibrary }'
 
 - // Install bower locally if not already installed either globally or locally; creates bowerLibrary file if run

--- a/build/_grunt.shade
+++ b/build/_grunt.shade
@@ -1,9 +1,9 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
-
 var gruntCliLibrary = '${ Path.Combine(nodeDir, "node_modules", "grunt-cli", "bin", "grunt") }'
 var gruntCliInstalled = '${ File.Exists(gruntCliLibrary) }'
-var gruntCliGloballyInstalled = '${ !gruntCliInstalled && TestCommand("grunt", "--version") }'
+
+default gruntCliGloballyInstalled = '${ !gruntCliInstalled && TestCommand("grunt", "--version") }'
 var gruntCmd = '${ gruntCliGloballyInstalled ? "grunt" : gruntCliLibrary }'
 
 - // Install grunt-cli locally if not already installed either globally or locally; creates gruntCliLibrary file if run

--- a/build/_grunt.shade
+++ b/build/_grunt.shade
@@ -1,13 +1,15 @@
 default currentDir = '${Directory.GetCurrentDirectory()}'
 default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
 
-var gruntCliInstalled = '${Directory.Exists(Path.Combine(nodeDir, "node_modules", "grunt-cli"))}'
+var gruntCliLibrary = '${ Path.Combine(nodeDir, "node_modules", "grunt-cli", "bin", "grunt") }'
+var gruntCliInstalled = '${ File.Exists(gruntCliLibrary) }'
 var gruntCliGloballyInstalled = '${ !gruntCliInstalled && TestCommand("grunt", "--version") }'
-var gruntCmd = '${ gruntCliGloballyInstalled ? "grunt" : Path.Combine(nodeDir, "node_modules", "grunt-cli") }'
+var gruntCmd = '${ gruntCliGloballyInstalled ? "grunt" : gruntCliLibrary }'
 
--// Install grunt-cli locally
+- // Install grunt-cli locally if not already installed either globally or locally; creates gruntCliLibrary file if run
 npm npmCommand='install ${E("npm_install_options")} --prefix ${nodeDir} grunt-cli' if='!(gruntCliGloballyInstalled || gruntCliInstalled)' once='installGruntCli'
 
--// Run grunt
-exec program='cmd' commandline='/C ${gruntCmd}' workingdir='${gruntDir}' if='gruntCliGloballyInstalled'
-node nodeCommand='${Path.Combine(nodeDir, "node_modules", "grunt-cli", "bin", "grunt")}' workingdir='${gruntDir}' if='!gruntCliGloballyInstalled'
+-// Run grunt-cli
+exec program='cmd' commandline='/C ${gruntCmd}' workingdir='${gruntDir}' if='gruntCliGloballyInstalled && !IsLinux'
+exec program='${gruntCmd}' workingdir='${gruntDir}' if='gruntCliGloballyInstalled && IsLinux'
+node nodeCommand='${gruntCmd}' workingdir='${gruntDir}' if='!gruntCliGloballyInstalled'

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -41,12 +41,6 @@ default Configuration='${E("Configuration")}'
   -// Find all dirs that contain a gruntfile.js file
   var gruntDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "gruntfile.js")}'
   grunt each='var gruntDir in gruntDirs'
-  @{
-      if (!IsMono)
-      {
-           CallTarget("clean-npm-modules");
-      }
-  }
 
 #clean-npm-modules if='!IsMono'
   -// Find all dirs that contain a package.json file

--- a/build/_node-install.shade
+++ b/build/_node-install.shade
@@ -9,27 +9,29 @@ default binDir = '${Path.Combine(Directory.GetCurrentDirectory(), "bin")}'
 default nodeVer = '0.10.28'
 default npmVer = '1.4.9'
 default nodeExeSha = '628FFD6C3577068C00CEC9F6F897F0EC8F5212D9'
-default nodeInstallDir = '${Path.Combine(binDir, "nodejs")}'
+default nodeDir = '${Path.Combine(binDir, "nodejs")}'
 
 var nodeExe = 'node.exe'
 var npmZip = 'npm-${npmVer}.zip'
 var nodeDist = 'http://nodejs.org/dist/'
 var nodeUrl = '${nodeDist}v${nodeVer}/${nodeExe}'
 var npmUrl = '${nodeDist}npm/${npmZip}'
-var nodeInstallExePath = '${Path.Combine(nodeInstallDir, nodeExe)}'
-var npmInstallZipPath = '${Path.Combine(nodeInstallDir, npmZip)}'
+var nodeInstallExePath = '${Path.Combine(nodeDir, nodeExe)}'
+var npmInstallZipPath = '${Path.Combine(nodeDir, npmZip)}'
+var nodeInstalled = '${ File.Exists(nodeInstallExePath) }'
 
-var doInstall = '${ !File.Exists(nodeInstallExePath) && !TestCommand("node", "--version") }'
+default nodeGloballyInstalled = '${ !nodeInstalled && TestCommand("node", "--version") }'
+var doInstall = '${ !(nodeGloballyInstalled || nodeInstalled) }'
 
 @{
   if (doInstall) {
     Log.Info("Installing nodejs locally");
 
-    if (Directory.Exists(nodeInstallDir))
+    if (Directory.Exists(nodeDir))
     {
-        Directory.Delete(nodeInstallDir, recursive: true);
+        Directory.Delete(nodeDir, recursive: true);
     }
-    Directory.CreateDirectory(nodeInstallDir);
+    Directory.CreateDirectory(nodeDir);
 
     // Download node
     var wc = new WebClient();
@@ -41,8 +43,8 @@ var doInstall = '${ !File.Exists(nodeInstallExePath) && !TestCommand("node", "--
     wc.DownloadFile(npmUrl, npmInstallZipPath);
 
     // Unzip npm
-    Log.Info(string.Format("Unzipping npm to {0}", nodeInstallDir));
-    ZipFile.ExtractToDirectory(npmInstallZipPath, nodeInstallDir);
+    Log.Info(string.Format("Unzipping npm to {0}", nodeDir));
+    ZipFile.ExtractToDirectory(npmInstallZipPath, nodeDir);
   }
 }
 


### PR DESCRIPTION
- don't confuse leftover folders with local presence of `bower` or `grunt-cli` libraries
- get `run-grunt` working on Linux machines when `grunt-cli` is installed globally
- don't clean up `node_modules` folders on every build; speed up `npm install`