### PR TITLE
Provide `deep-clean` target to remove folders `git clean` cannot

### DIFF
--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -42,10 +42,20 @@ default Configuration='${E("Configuration")}'
   var gruntDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "gruntfile.js")}'
   grunt each='var gruntDir in gruntDirs'
 
-#clean-npm-modules if='!IsMono'
+#clean-bin-folder
+  rimraf rimrafDir='bin' if='Directory.Exists("bin")'
+
+#clean-npm-modules
   -// Find all dirs that contain a package.json file
-  var npmDirs = '${GetDirectoriesContaining(Directory.GetCurrentDirectory(), "package.json").Select(d => Path.Combine(d, "node_modules"))}'
-  robocopy-delete dir='${npmDir}' each='var npmDir in npmDirs'
+  var npmDirs = '${
+    GetDirectoriesContaining(Directory.GetCurrentDirectory(), "package.json")
+      .Select(directory => Path.Combine(directory, "node_modules"))
+      .Where(directory => Directory.Exists(directory))
+  }'
+  rimraf each='var rimrafDir in npmDirs'
+
+-// Target order is important because clean-npm-modules may (re)create bin folder.
+#deep-clean .clean-npm-modules .clean-bin-folder description='Clean folders that may cause problems for `git clean`.'
 
 #repo-initialize target='initialize'
   k-restore

--- a/build/_rimraf.shade
+++ b/build/_rimraf.shade
@@ -1,0 +1,16 @@
+default currentDir = '${Directory.GetCurrentDirectory()}'
+default workingDir = '${ currentDir }'
+default nodeDir = '${Path.Combine(currentDir, "bin", "nodejs")}'
+default rimrafLibrary = '${ Path.Combine(nodeDir, "node_modules", "rimraf", "bin.js") }'
+var rimrafInstalled = '${ File.Exists(Path.Combine(rimrafLibrary)) }'
+
+default rimrafGloballyInstalled = '${ !rimrafInstalled && TestCommand("rimraf", "::") }'
+var rimrafCmd = '${ rimrafGloballyInstalled ? "rimraf" : rimrafLibrary }'
+
+- // Install rimraf locally if not already installed either globally or locally; creates rimrafLibrary file if run
+npm npmCommand='install ${E("npm_install_options")} --prefix ${nodeDir} rimraf' if='!(rimrafGloballyInstalled || rimrafInstalled)' once='installRimraf'
+
+- // Run rimraf
+exec program='cmd' commandline='/C ${rimrafCmd} ${rimrafDir}' workingdir='${workingDir}' if='rimrafGloballyInstalled && !IsLinux'
+exec program='${rimrafCmd}' commandline='${rimrafDir}' workingdir='${workingDir}' if='rimrafGloballyInstalled && IsLinux'
+node nodeCommand='${rimrafCmd} ${rimrafDir}' workingdir='${workingDir}' if='!rimrafGloballyInstalled'


### PR DESCRIPTION
- use `rimraf` instead of noisier, slower `robocopy-delete`
- _rimraf.shade is modeled after bower.shade