### PR TITLE
Do not use deprecated `dnvm -x86` switch

### DIFF
--- a/build-template/build.cmd
+++ b/build-template/build.cmd
@@ -20,9 +20,9 @@ IF EXIST packages\KoreBuild goto run
 .nuget\NuGet.exe install Sake -version 0.2 -o packages -ExcludeVersion
 
 IF "%SKIP_DNX_INSTALL%"=="1" goto run
-CALL packages\KoreBuild\build\dnvm upgrade -runtime CLR -x86
-CALL packages\KoreBuild\build\dnvm install default -runtime CoreCLR -x86
+CALL packages\KoreBuild\build\dnvm upgrade -runtime CLR -arch x86
+CALL packages\KoreBuild\build\dnvm install default -runtime CoreCLR -arch x86
 
 :run
-CALL packages\KoreBuild\build\dnvm use default -runtime CLR -x86
+CALL packages\KoreBuild\build\dnvm use default -runtime CLR -arch x86
 packages\Sake\tools\Sake.exe -I packages\KoreBuild\build -f makefile.shade %*


### PR DESCRIPTION
- avoid `The -x86 switch has been deprecated. Use the '-arch x86' parameter instead`