### PR TITLE
Fix build failures when source is under a directory with spaces in the name

### DIFF
--- a/build/_bower.shade
+++ b/build/_bower.shade
@@ -10,9 +10,9 @@ var bowerCmd = '${ bowerGloballyInstalled ? "bower" : bowerLibrary }'
 - bowerCommand = bowerCommand + " --config.interactive=false";
 
 - // Install bower locally if not already installed either globally or locally; creates bowerLibrary file if run
-npm npmCommand='install ${E("npm_install_options")} --prefix ${nodeDir} bower' if='!(bowerGloballyInstalled || bowerInstalled)' once='installBower'
+npm npmCommand='install ${E("npm_install_options")} --prefix "${nodeDir}" bower' if='!(bowerGloballyInstalled || bowerInstalled)' once='installBower'
 
 - // Run bower
 exec program='cmd' commandline='/C ${bowerCmd} ${bowerCommand}' workingdir='${bowerDir}' if='bowerGloballyInstalled && !IsLinux'
 exec program='${bowerCmd}' commandline='${bowerCommand}' workingdir='${bowerDir}' if='bowerGloballyInstalled && IsLinux'
-node nodeCommand='${bowerCmd} ${bowerCommand}' workingdir='${bowerDir}' if='!bowerGloballyInstalled'
+node nodeCommand='"${bowerCmd}" ${bowerCommand}' workingdir='${bowerDir}' if='!bowerGloballyInstalled'

--- a/build/_grunt.shade
+++ b/build/_grunt.shade
@@ -7,9 +7,9 @@ default gruntCliGloballyInstalled = '${ !gruntCliInstalled && TestCommand("grunt
 var gruntCmd = '${ gruntCliGloballyInstalled ? "grunt" : gruntCliLibrary }'
 
 - // Install grunt-cli locally if not already installed either globally or locally; creates gruntCliLibrary file if run
-npm npmCommand='install ${E("npm_install_options")} --prefix ${nodeDir} grunt-cli' if='!(gruntCliGloballyInstalled || gruntCliInstalled)' once='installGruntCli'
+npm npmCommand='install ${E("npm_install_options")} --prefix "${nodeDir}" grunt-cli' if='!(gruntCliGloballyInstalled || gruntCliInstalled)' once='installGruntCli'
 
 -// Run grunt-cli
 exec program='cmd' commandline='/C ${gruntCmd}' workingdir='${gruntDir}' if='gruntCliGloballyInstalled && !IsLinux'
 exec program='${gruntCmd}' workingdir='${gruntDir}' if='gruntCliGloballyInstalled && IsLinux'
-node nodeCommand='${gruntCmd}' workingdir='${gruntDir}' if='!gruntCliGloballyInstalled'
+node nodeCommand='"${gruntCmd}"' workingdir='${gruntDir}' if='!gruntCliGloballyInstalled'

--- a/build/_npm.shade
+++ b/build/_npm.shade
@@ -5,12 +5,12 @@ default npmDir = '${currentDir}'
 node-install once='installNode'
 
 var npmFile = '${ Path.Combine(nodeDir, "npm.cmd") }'
-var npmCmd = '${ File.Exists(npmFile) ? npmFile : "npm" }'
+var npmCmd = '${ File.Exists(npmFile) ? ("\"" + npmFile + "\"") : "npm" }'
 
 - // Ensure nodeDir exists. npmCommand is likely a package installation targeting that directory.
 @{
   Directory.CreateDirectory(nodeDir);
 }
 
-exec program='cmd' commandline='/C ${npmCmd} ${npmCommand}' workingdir='${npmDir}' if='!IsLinux'
+exec program='cmd' commandline='/S /C "${npmCmd} ${npmCommand}"' workingdir='${npmDir}' if='!IsLinux'
 exec program='${npmCmd}' commandline='${npmCommand}' workingdir='${npmDir}' if='IsLinux'

--- a/build/_rimraf.shade
+++ b/build/_rimraf.shade
@@ -8,9 +8,9 @@ default rimrafGloballyInstalled = '${ !rimrafInstalled && TestCommand("rimraf", 
 var rimrafCmd = '${ rimrafGloballyInstalled ? "rimraf" : rimrafLibrary }'
 
 - // Install rimraf locally if not already installed either globally or locally; creates rimrafLibrary file if run
-npm npmCommand='install ${E("npm_install_options")} --prefix ${nodeDir} rimraf' if='!(rimrafGloballyInstalled || rimrafInstalled)' once='installRimraf'
+npm npmCommand='install ${E("npm_install_options")} --prefix "${nodeDir}" rimraf' if='!(rimrafGloballyInstalled || rimrafInstalled)' once='installRimraf'
 
 - // Run rimraf
-exec program='cmd' commandline='/C ${rimrafCmd} ${rimrafDir}' workingdir='${workingDir}' if='rimrafGloballyInstalled && !IsLinux'
-exec program='${rimrafCmd}' commandline='${rimrafDir}' workingdir='${workingDir}' if='rimrafGloballyInstalled && IsLinux'
-node nodeCommand='${rimrafCmd} ${rimrafDir}' workingdir='${workingDir}' if='!rimrafGloballyInstalled'
+exec program='cmd' commandline='/C ${rimrafCmd} "${rimrafDir}"' workingdir='${workingDir}' if='rimrafGloballyInstalled && !IsLinux'
+exec program='${rimrafCmd}' commandline='"${rimrafDir}"' workingdir='${workingDir}' if='rimrafGloballyInstalled && IsLinux'
+node nodeCommand='"${rimrafCmd}" "${rimrafDir}"' workingdir='${workingDir}' if='!rimrafGloballyInstalled'

--- a/build/_verify-authenticode.shade
+++ b/build/_verify-authenticode.shade
@@ -20,7 +20,7 @@ default expectedHash = ''
         WorkingDirectory = workingdir,
         FileName = signToolExe,
         RedirectStandardOutput = true,
-        Arguments = "verify /pa /v " + verifyFilePath,
+        Arguments = "verify /pa /v \"" + verifyFilePath + "\"",
     };
 
     var signTool = Process.Start(processStartInfo);


### PR DESCRIPTION
- aspnet/Mvc#2082
- problems specific to local `node` and related installations
 - quote authenticode verification target
 - quote local `node` library paths
 - quote local `npm.cmd` path (with ye olde `/S` double-quoting hack)
 - quote `--prefix` values in `npm install` commands
 - quote `rimraf` directories to delete