### PR TITLE
Rename kpm to dnu in standard goal scripts

### DIFF
--- a/build/_k-restore.shade
+++ b/build/_k-restore.shade
@@ -6,5 +6,5 @@ k-restore
 
 default restore_options='${E("NUGET3_restore_options")}'
 
-exec program='cmd' commandline='/C kpm restore${restore_options}' if='!IsMono'
-exec program='kpm' commandline='restore${restore_options}' if='IsMono'
+exec program='cmd' commandline='/C dnu restore${restore_options}' if='!IsMono'
+exec program='dnu' commandline='restore${restore_options}' if='IsMono'

--- a/build/_kpm-build.shade
+++ b/build/_kpm-build.shade
@@ -17,5 +17,5 @@ var projectName='${Path.GetFileName(projectFolder)}'
 var projectBin='${Path.Combine(projectFolder, "bin", configuration)}'
 
 directory delete="${projectBin}"
-exec program='cmd' commandline='/C kpm build${build_options} ${projectFolder} --configuration ${configuration}' if='!IsMono'
-exec program='kpm' commandline='build${build_options} ${projectFolder} --configuration ${configuration}' if='IsMono'
+exec program='cmd' commandline='/C dnu build${build_options} ${projectFolder} --configuration ${configuration}' if='!IsMono'
+exec program='dnu' commandline='build${build_options} ${projectFolder} --configuration ${configuration}' if='IsMono'

--- a/build/_kpm-pack.shade
+++ b/build/_kpm-pack.shade
@@ -17,6 +17,6 @@ var projectName='${Path.GetFileName(projectFolder)}'
 var projectBin='${Path.Combine(projectFolder, "bin", configuration)}'
 
 directory delete="${projectBin}"
-exec program='cmd' commandline='/C kpm pack${pack_options} ${projectFolder} --configuration ${configuration}' if='!IsMono'
-exec program='kpm' commandline='pack${pack_options} ${projectFolder} --configuration ${configuration}' if='IsMono'
+exec program='cmd' commandline='/C dnu pack${pack_options} ${projectFolder} --configuration ${configuration}' if='!IsMono'
+exec program='dnu' commandline='pack${pack_options} ${projectFolder} --configuration ${configuration}' if='IsMono'
 copy sourceDir='${projectBin}' outputDir='${Path.Combine(BUILD_DIR, projectName)}'

--- a/build/_kpm-publish.shade
+++ b/build/_kpm-publish.shade
@@ -17,5 +17,5 @@ default targetPackagesDir=''
                            .Where(p => !p.EndsWith(".symbols.nupkg"));
 }
 
-exec program='cmd' commandline='/C kpm packages add ${package} ${targetPackagesDir}' if='!IsMono' each='var package in packages'
-exec program='kpm' commandline='packages add ${package} ${targetPackagesDir}' if='IsMono' each='var package in packages'
+exec program='cmd' commandline='/C dnu packages add ${package} ${targetPackagesDir}' if='!IsMono' each='var package in packages'
+exec program='dnu' commandline='packages add ${package} ${targetPackagesDir}' if='IsMono' each='var package in packages'


### PR DESCRIPTION
parent https://github.com/aspnet/Universe/issues/186

@davidfowl @muratg 

Following the gradual adoption strategy. Only rename the kpm inside standard goal scripts, so nothing will be broken.

I see we still have standard goals with names like `_k-restore.shade` and `_kpm-build.shade`. We may want to replace `k` with `dnx` and replace `kpm` with `dnu` later.