### PR TITLE
Update dnvm feeds in KoreBuild

### DIFF
--- a/build/dnvm.ps1
+++ b/build/dnvm.ps1
@@ -76,7 +76,7 @@ Set-Variable -Option Constant "CommandFriendlyName" ".NET Version Manager"
 Set-Variable -Option Constant "DefaultUserDirectoryName" ".dnx"
 Set-Variable -Option Constant "OldUserDirectoryNames" @(".kre", ".k")
 Set-Variable -Option Constant "RuntimePackageName" "dnx"
-Set-Variable -Option Constant "DefaultFeed" "https://www.myget.org/F/aspnetvnext/api/v2"
+Set-Variable -Option Constant "DefaultFeed" "https://www.myget.org/F/aspnetrelease/api/v2"
 Set-Variable -Option Constant "CrossGenCommand" "k-crossgen"
 Set-Variable -Option Constant "CommandPrefix" "dnvm-"
 Set-Variable -Option Constant "DefaultArchitecture" "x86"

--- a/build/dnvm.sh
+++ b/build/dnvm.sh
@@ -10,7 +10,7 @@ _DNVM_RUNTIME_SHORT_NAME="DNX"
 _DNVM_RUNTIME_FOLDER_NAME=".dnx"
 _DNVM_COMMAND_NAME="dnvm"
 _DNVM_VERSION_MANAGER_NAME=".NET Version Manager"
-_DNVM_DEFAULT_FEED="https://www.myget.org/F/aspnetvnext/api/v2"
+_DNVM_DEFAULT_FEED="https://www.myget.org/F/aspnetrelease/api/v2"
 _DNVM_HOME_VAR_NAME="DNX_HOME"
 
 [ "$_DNVM_BUILDNUMBER" = "{{*" ] && _DNVM_BUILDNUMBER="HEAD"


### PR DESCRIPTION
KoreBuild, when building in `release`, needs to point at the release feed.

/cc @BrennanConroy @muratg 