### PR TITLE
Set the file version environment variable

### DIFF
--- a/build/BuildEnv.shade
+++ b/build/BuildEnv.shade
@@ -3,6 +3,22 @@ use namespace="System"
 
 functions
   @{
+    string CreateDayBasedVersionNumber()
+    {
+        var start = new DateTime(2015, 1, 1);
+        var now = DateTime.UtcNow;
+            
+        string version = "0";
+        // If the computer date is set before the start date, then the version is 0
+        if (now >= start)
+        {
+            var monthsSinceStart = (now.Year - start.Year) * 12 + now.Month;
+            version = monthsSinceStart.ToString("000") + now.Day.ToString("00");
+        }
+
+        return version;
+    }
+
     string BuildNumber
     {
         get 

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -20,6 +20,10 @@ default Configuration='${E("Configuration")}'
   {
     E("DNX_AUTHOR", AUTHORS);
   }
+  if (string.IsNullOrEmpty(E("DNX_ASSEMBLY_FILE_VERSION")))
+  {
+    E("DNX_ASSEMBLY_FILE_VERSION", CreateDayBasedVersionNumber());
+  }
   if (string.IsNullOrEmpty(Configuration))
   {
     Configuration = "Debug";


### PR DESCRIPTION
This change is to set an environment variable for the AssemblyFileVersion attribute. 

The version has 5 characters, the first 3 are the number of months since 2015/1/1 and the last 2 are the day of the month. @joeloff suggested this format since it is used in other places. For example, today's version is 00327.

Please review: @joeloff @pranavkm 

@Eilon, @davidfowl are you okay with the version in this format?

There is a DNX change coming soon that will actually write the attribute. 

Part of the fix for https://github.com/aspnet/dnx/issues/1504