### PR TITLE
New assembly file version (with year)

### DIFF
--- a/build/BuildEnv.shade
+++ b/build/BuildEnv.shade
@@ -12,8 +12,8 @@ functions
         // If the computer date is set before the start date, then the version is 0
         if (now >= start)
         {
-            var monthsSinceStart = (now.Year - start.Year) * 12 + now.Month;
-            version = monthsSinceStart.ToString("000") + now.Day.ToString("00");
+            var yearsSinceStart = (now.Year - start.Year) + 1;
+            version = yearsSinceStart + now.ToString("MMdd");
         }
 
         return version;


### PR DESCRIPTION
I was asked by the authority (@Eilon) to add the year information in the file version even if that gives us only 7 years of versions.

So now it is: `<years since 2015 (1 digit) +1 > <current month (2 digits)> <current day (2 digits)>`

@joeloff 