### PR TITLE
change to use cmd to launch git on Windows

### DIFF
--- a/build/_git.shade
+++ b/build/_git.shade
@@ -1,5 +1,7 @@
 
 default gitFolder=''
 
-exec program='git' commandline='${gitCommand}' workingdir='${gitFolder}'
+-// Use cmd to invoke git so that people who have git as a 'cmd'
+exec program='cmd' commandline='/C git ${gitCommand}' workingdir='${gitFolder}' if='!IsMono'
+exec program='git' commandline='${gitCommand}' workingdir='${gitFolder}' if='IsMono'
 


### PR DESCRIPTION
I use a `git.cmd` that launches git, because I store it in my OneDrive to allow updating. In order to launch it, we have to use `cmd /C` :(. This changes our `git` task to do that

/cc @lodejard 