### PR TITLE
Add `Quiet` default to enable conditionalizing `Log.Info()` calls

### DIFF
--- a/build/_copy.shade
+++ b/build/_copy.shade
@@ -1,0 +1,34 @@
+
+use import="Files"
+
+default include='**/*.*'
+default exclude=''
+default overwrite='${false}'
+default Quiet='${ false }'
+
+@{
+  var copyFiles = Files.BasePath(Path.GetFullPath(sourceDir));
+  if (!string.IsNullOrEmpty(include))
+  {
+    copyFiles = copyFiles.Include(include);
+  }
+  if (!string.IsNullOrEmpty(exclude))
+  {
+    copyFiles = copyFiles.Exclude(exclude);
+  }
+  foreach(var copyFile in copyFiles)
+  {
+    if (!Quiet)
+    {
+        Log.Info(string.Format("Copying {0}", copyFile));
+    }
+
+    var sourceFile = Path.Combine(sourceDir, copyFile);
+    var outputFile = Path.Combine(outputDir, copyFile);
+    if (!Directory.Exists(Path.GetDirectoryName(outputFile)))
+    {
+      Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
+    }
+    File.Copy(sourceFile, outputFile, overwrite);
+  }
+}

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -10,6 +10,7 @@ default TARGET_DIR='${Path.Combine(BASE_DIR, "artifacts")}'
 default BUILD_DIR='${Path.Combine(TARGET_DIR, "build")}'
 default TEST_DIR='${Path.Combine(TARGET_DIR, "test")}'
 default Configuration='${E("Configuration")}'
+default Quiet='${ false }'
 
 @{
   if (string.IsNullOrEmpty(E("DNX_BUILD_VERSION")))
@@ -192,6 +193,7 @@ default Configuration='${E("Configuration")}'
     E("NUGET3_restore_options"," --quiet");
     E("bower_install_options","--quiet");
     E("npm_install_options","--quiet");
+    Quiet = true;
   }
 
 #--parallel


### PR DESCRIPTION
- use in new `_copy.shade` which overrides the Sake default