### PR TITLE
Build projects in one go

### DIFF
--- a/build/BuildEnv.shade
+++ b/build/BuildEnv.shade
@@ -33,4 +33,12 @@ functions
             return Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null;
         }
     }
+    
+    bool IsBuildV2
+    {
+        get 
+        { 
+            return Environment.GetEnvironmentVariable("KOREBUILD_BUILD_V2") == "1"; 
+        }
+    }
   }

--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -30,6 +30,8 @@ default Quiet='${ false }'
     Configuration = "Debug";
     E("Configuration", Configuration);
   }
+  
+  Log.Info("Build v2: " + IsBuildV2);
 }
 
 #restore-npm-modules
@@ -88,19 +90,27 @@ default Quiet='${ false }'
 
 #build-compile target='compile' if='Directory.Exists("src")'
   @{
-    var projectFiles = Files.Include("src/**/project.json").ToList();
-    if (ShouldRunInParallel)
+    if (IsBuildV2) 
     {
-        Parallel.ForEach(projectFiles, projectFile => DnuPack(projectFile, BUILD_DIR, Configuration));
+        const string buildPattern = "src/**";
+        DnuPack(buildPattern, BUILD_DIR, Configuration);
     }
     else
     {
-        projectFiles.ForEach(projectFile => DnuPack(projectFile, BUILD_DIR, Configuration));
+        var projectFiles = Files.Include("src/**/project.json").ToList();
+        if (ShouldRunInParallel)
+        {
+            Parallel.ForEach(projectFiles, projectFile => DnuPack(projectFile, BUILD_DIR, Configuration));
+        }
+        else
+        {
+            projectFiles.ForEach(projectFile => DnuPack(projectFile, BUILD_DIR, Configuration));
+        }
     }
-
+    
     foreach (var nupkg in Files.Include(Path.Combine(BUILD_DIR, "*/*.nupkg")))
     {
-      File.Copy(nupkg, Path.Combine(BUILD_DIR, Path.GetFileName(nupkg)), true);
+        File.Copy(nupkg, Path.Combine(BUILD_DIR, Path.GetFileName(nupkg)), true);
     }
   }
 
@@ -227,16 +237,16 @@ functions @{
       if(!IsLinux)
       {
         processStartInfo = new ProcessStartInfo {
-      	UseShellExecute = false,
-      	FileName = "cmd",
-      	Arguments = "/C " + program + " " + commandline,
+        UseShellExecute = false,
+        FileName = "cmd",
+        Arguments = "/C " + program + " " + commandline,
         };
       } else
       {
-      	processStartInfo = new ProcessStartInfo {
-      	UseShellExecute = false,
-      	FileName = program,
-      	Arguments = commandline,
+        processStartInfo = new ProcessStartInfo {
+        UseShellExecute = false,
+        FileName = program,
+        Arguments = commandline,
         };
       }
       try
@@ -283,4 +293,9 @@ macro name="DnuBuild" projectFile='string' configuration='string'
 
 macro name="DnuPack" projectFile='string' kpmPackOutputDir='string' configuration='string'
     kpm-pack
+    
+macro name="DeleteFolder" delete='string'
+    directory
 
+macro name="CopyFolder" sourceDir='string' outputDir='string'
+    copy

--- a/build/_kpm-build.shade
+++ b/build/_kpm-build.shade
@@ -12,10 +12,47 @@ configuration=''
 
 default configuration = 'Debug'
 default build_options='${E("NUGET3_build_options")}'
-var projectFolder='${Path.GetDirectoryName(projectFile)}'
-var projectName='${Path.GetFileName(projectFolder)}'
-var projectBin='${Path.Combine(projectFolder, "bin", configuration)}'
 
-directory delete="${projectBin}"
-exec program='cmd' commandline='/C dnu build${build_options} ${projectFolder} --configuration ${configuration}' if='!IsMono'
-exec program='dnu' commandline='build${build_options} ${projectFolder} --configuration ${configuration}' if='IsMono'
+@{
+    if (IsBuildV2)
+    {
+        var projectFolders = projectFile.Split((char)';')
+            .SelectMany(pattern => Files.Include(pattern + "/project.json"))
+            .Select(proj => Path.GetDirectoryName(proj))
+            .ToList();
+            
+        foreach(var projFolder in projectFolders) 
+        { 
+            DeleteFolder(Path.Combine(projFolder, "bin", configuration));
+        }
+        
+        var projectsArg=projectFile.Replace(";", " ");
+        var dnuArgs=string.Format("build{0} {1} --configuration {2}", build_options, projectsArg, configuration);
+        if (!IsMono) 
+        {
+            Exec("cmd", "/C dnu " + dnuArgs);
+        }
+        else
+        {
+            Exec("dnu", dnuArgs);
+        }
+    }
+    else
+    {
+        var projectFolder=Path.GetDirectoryName(projectFile);
+        var projectName=Path.GetFileName(projectFolder);
+        var projectBin=Path.Combine(projectFolder, "bin", configuration);
+        
+        DeleteFolder(projectBin);
+        
+        var dnuArgs=string.Format("build{0} {1} --configuration {2}", build_options, projectFolder, configuration);
+        if (!IsMono) 
+        {
+            Exec("cmd", "/C dnu " + dnuArgs);
+        }
+        else
+        {
+            Exec("dnu", dnuArgs);
+        }
+    }
+}

--- a/build/_kpm-pack.shade
+++ b/build/_kpm-pack.shade
@@ -15,11 +15,56 @@ configuration=''
 
 default configuration = 'Debug'
 default pack_options='${E("NUGET3_pack_options")}'
-var projectFolder='${Path.GetDirectoryName(projectFile)}'
-var projectName='${Path.GetFileName(projectFolder)}'
-var projectBin='${Path.Combine(projectFolder, "bin", configuration)}'
 
-directory delete="${projectBin}"
-exec program='cmd' commandline='/C dnu pack${pack_options} ${projectFolder} --configuration ${configuration}' if='!IsMono'
-exec program='dnu' commandline='pack${pack_options} ${projectFolder} --configuration ${configuration}' if='IsMono'
-copy sourceDir='${projectBin}' outputDir='${Path.Combine(kpmPackOutputDir, projectName)}'
+@{
+    if (IsBuildV2)
+    {
+        var projectFolders = projectFile.Split((char)';')
+            .SelectMany(pattern => Files.Include(pattern + "/project.json"))
+            .Select(proj => Path.GetDirectoryName(proj))
+            .ToList();
+            
+        foreach(var projFolder in projectFolders) 
+        { 
+            DeleteFolder(Path.Combine(projFolder, "bin", configuration));
+        }
+        
+        var projectsArg=projectFile.Replace(";", " ");
+        var dnuArgs=string.Format("pack{0} {1} --configuration {2}", pack_options, projectsArg, configuration);
+        if (!IsMono) 
+        {
+            Exec("cmd", "/C dnu " + dnuArgs);
+        }
+        else
+        {
+            Exec("dnu", dnuArgs);
+        }
+        
+        foreach(var projFolder in projectFolders) 
+        { 
+            CopyFolder(
+                Path.Combine(projFolder, "bin", configuration), 
+                Path.Combine(kpmPackOutputDir, Path.GetFileName(projFolder)));
+        }
+    }
+    else
+    {
+        var projectFolder=Path.GetDirectoryName(projectFile);
+        var projectName=Path.GetFileName(projectFolder);
+        var projectBin=Path.Combine(projectFolder, "bin", configuration);
+        
+        DeleteFolder(projectBin);
+        
+        var dnuArgs=string.Format("pack{0} {1} --configuration {2}", pack_options, projectFolder, configuration);
+        if (!IsMono) 
+        {
+            Exec("cmd", "/C dnu " + dnuArgs);
+        }
+        else
+        {
+            Exec("dnu", dnuArgs);
+        }
+
+        CopyFolder(projectBin, Path.Combine(kpmPackOutputDir, projectName));
+    }
+}


### PR DESCRIPTION
Add support for `dnu build src/**`. Unless a particular environment variable is set, the build will still work as it does today so this change is not breaking and should not impact anything.