### PR TITLE
Pass correct targets for travis and appveryor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: csharp
 sudo: false
 script:
-  - ./build.sh --quiet verify
+  - ./build.sh pack

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 init:
   - git config --global core.autocrlf true
 build_script:
-  - build.cmd --quiet verify
+  - build.cmd pack
 clone_depth: 1
 test: off
 deploy: off


### PR DESCRIPTION
The internal CI passes `pack` as argument. External CIs should do the same. 
`--quiet verify` doesn't make sense for Universe.

Fixes https://github.com/aspnet/Universe/issues/231

Please review @pranavkm @anurse 