### PR TITLE
Pin build scripts

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -192,6 +192,12 @@ var buildTarget = "compile"
             throw new Exception("COHERENCE_FEED not specified. Usually this is Packages-NoTimestamp directory of Coherence-Signed.");
         }
 
+        var korebuildVersion = Environment.GetEnvironmentVariable("KOREBUILD_VERSION");
+        if (string.IsNullOrEmpty(korebuildVersion))
+        {
+            throw new Exception("KOREBUILD_VERSION environment variable is not specified.");
+        }
+
         var excludeReposForJson = new[]
         {
           "Coherence",
@@ -216,7 +222,7 @@ var buildTarget = "compile"
 
             var repoPath = Path.Combine(Directory.GetCurrentDirectory(), repo);
 
-            Exec("dnx", string.Format(@".\tools\PinVersion run ""{0}"" ""{1}""", repo, coherenceFeed), string.Empty);
+            Exec("dnx", string.Format(@".\tools\PinVersion run ""{0}"" ""{1}"" ""{2}""", repo, coherenceFeed, korebuildVersion), string.Empty);
 
             // Build projects to produce project.lock.json
             Exec("build.cmd", "compile", repo);
@@ -661,8 +667,8 @@ functions
 
             return true;
         }
-        
-        static IEnumerable<string> GetRepositoriesToBuild() 
+
+        static IEnumerable<string> GetRepositoriesToBuild()
         {
             IEnumerable<string> reposToBuild = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
                 // The repos list is topologically sorted based on build order
@@ -703,7 +709,7 @@ functions
                 "CORS",
                 "Entropy",
             };
-            
+
             var repositoryInclude = Environment.GetEnvironmentVariable("KOREBUILD_REPOSITORY_INCLUDE");
             if (!string.IsNullOrEmpty(repositoryInclude))
             {
@@ -711,14 +717,14 @@ functions
                     repositoryInclude.Split(new string[] {","}, StringSplitOptions.RemoveEmptyEntries),
                     StringComparer.OrdinalIgnoreCase);
             }
-            
+
             var repositoryExclude = Environment.GetEnvironmentVariable("KOREBUILD_REPOSITORY_EXCLUDE");
-            if (!string.IsNullOrEmpty(repositoryExclude)) 
+            if (!string.IsNullOrEmpty(repositoryExclude))
             {
                 var reposToExclude = repositoryExclude.Split(new string[] {","}, StringSplitOptions.RemoveEmptyEntries);
                 reposToBuild = reposToBuild.Except(reposToExclude);
             }
-            
+
             return reposToBuild.ToList();
         }
     }

--- a/tools/PinVersion/Program.cs
+++ b/tools/PinVersion/Program.cs
@@ -90,16 +90,16 @@ namespace PinVersion
             }
 
             var buildCmdFile = buildCmdFiles[0];
-            var buildCmdFileContent = File.ReadAllText(buildCmdFile);
-            buildCmdFileContent = buildCmdFileContent.Replace(
-                "SET BUILDCMD_KOREBUILD_VERSION=\"\"",
-                $"SET BUILDCMD_KOREBUILD_VERSION={korebuildVersion}");
-            buildCmdFileContent = buildCmdFileContent.Replace(
-                "SET BUILDCMD_DNX_VERSION=\"\"",
-                $"SET BUILDCMD_DNX_VERSION={dnxPackage.Version.ToNormalizedString()}");
+            var allLines = File.ReadLines(buildCmdFile).ToList();
+
+            var index = allLines.FindIndex((line) => line.StartsWith("SET BUILDCMD_KOREBUILD_VERSION="));
+            allLines[index] = $"SET BUILDCMD_KOREBUILD_VERSION={korebuildVersion}";
+
+            index = allLines.FindIndex((line) => line.StartsWith("SET BUILDCMD_DNX_VERSION="));
+            allLines[index] = $"SET BUILDCMD_DNX_VERSION={dnxPackage.Version.ToNormalizedString()}";
 
             // Replace all content of the file
-            File.WriteAllText(buildCmdFile, buildCmdFileContent);
+            File.WriteAllLines(buildCmdFile, allLines);
         }
     }
 }


### PR DESCRIPTION
This is to enable pinning build scripts like `build.cmd` to the exact version that we want.

@pranavkm 

Related PR:
https://github.com/aspnet/Diagnostics/pull/165