### PR TITLE
Call correct build.sh when building repos.

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -360,7 +360,7 @@ var buildTarget = "compile"
 
                 if (IsMono)
                 {
-                    Exec("build.sh", buildTarget, repo);
+                    Exec(Path.Combine(repo, "build.sh"), buildTarget, repo);
                 }
                 else
                 {
@@ -419,7 +419,7 @@ var buildTarget = "compile"
         {
             if (IsMono)
             {
-                Exec("build.sh", "install", repo);
+                Exec(Path.Combine(repo, "build.sh"), "install", repo);
             }
             else
             {


### PR DESCRIPTION
Mono has inconsistent behavior in Process.Start (which is what Exec calls). Consider this directory structure

base
base/build.sh
base/sub
base/sub/build.sh

If $PWD is base and we call Process.Start with ProcessStartInfo { FileName = "build.sh", WorkingDirectory = "sub" }, the expected behavior (i.e. what .NET does on Windows) is that base\sub\build.sh would get started with a working directory of base/sub. However, base/build.sh gets called instead. For whatever reason, the same does not happen when trying to start a binary executable.

Because of this behavior, the universe build is broken on Linux. After change d679c85aa386f00afde6ce7062f286dedb76c7f9, the universe build.sh script does not get KoreBuild anymore and all builds fail because universe/build.sh is being called instead of universe/<repo>/build.sh.

The solution is to explicitly pass Exec the path to each repo's build.sh script.