### PR TITLE
Support restoring with .NET Core

### DIFF
--- a/build/_k-restore.shade
+++ b/build/_k-restore.shade
@@ -10,6 +10,10 @@ restoreDir=''
 default currentDir = '${ Directory.GetCurrentDirectory() }'
 default restoreDir = '${ currentDir }'
 
+-// Set KOREBUILD_DNU_RESTORE_CORECLR environment variable to any value and `dnu restore` will use Core CLR.
+var useCore = '${ E("KOREBUILD_DNU_RESTORE_CORECLR") }'
+default restoreUse='${ string.IsNullOrEmpty(useCore) ? string.Empty : "default -runtime coreclr" }'
+
 default restore_options=' ${ E("KOREBUILD_DNU_RESTORE_OPTIONS") } ${ IsLinux ? string.Empty : "--parallel" }'
 
-dnu command='restore${ restore_options }' workingDir='${ restoreDir }'
+dnu command='restore${ restore_options }' workingDir='${ restoreDir }' dnvmUse='${ restoreUse }'


### PR DESCRIPTION
- infrastructure for switching restores everywhere i.e. addressing #290
- e.g. add `KOREBUILD_DNU_RESTORE_CORECLR` setting to `.travis.yml` files, especially if using Trusty