### PR TITLE
Adding directory existence check for nuget-install

### DIFF
--- a/build/_k-standard-goals.shade
+++ b/build/_k-standard-goals.shade
@@ -202,7 +202,7 @@ default NUGET_FEED = 'https://api.nuget.org/v3/index.json'
     }
   }
 
-#nuget-install target='install' description='Install NuGet packages to local repo'
+#nuget-install target='install' if='Directory.Exists("src")' description='Install NuGet packages to local repo'
   kpm-publish sourcePackagesDir='${BUILD_DIR}' targetPackagesDir='${E("PACKAGES_PUBLISH_DIR")}'
   nuget-resilient-publish sourcePackagesDir='${BUILD_DIR}' nugetFeed='${E("NUGET_PUBLISH_FEED")}' if='!string.IsNullOrEmpty(E("NUGET_PUBLISH_FEED"))'
 


### PR DESCRIPTION
Removing the placeholder project in https://github.com/aspnet/ServerTests/pull/14 broke our CI. This is because nothing was built and the nuget-install step tries to publish from the non-existent `artifacts/build` directory. I'm thinking that the easiest fix is to just check for the existence of the build directory for nuget-install, thoughts? Is there a way for me to verify this fixes the issue before merging the PR?

@pranavkm @victorhurdugaci @rynowak 