### PR TITLE
fix line endings in DorkBuild

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,9 +4,9 @@
 * text=auto
 
 ###############################################################################
-# Make sh files under the build directory always have LF as line endings
+# Make sh files always have LF as line endings
 ###############################################################################
-build/*.sh eol=lf
+*.sh eol=lf
 
 
 ###############################################################################


### PR DESCRIPTION
The line-endings for the DorkBuild scripts were being set to CRLF on the CI when producing the DorkBuild package, which caused issues when using DorkBuild on non-Windows. This should ensure that the next DorkBuild build has the right line endings. It's a safe change because we use it on all of our other repos (and `.sh` **should** always use `\n` anyway)

/cc @victorhurdugaci 