### PR TITLE
Build instead of compile for samples

### DIFF
--- a/KoreBuild-dotnet/build/_dotnet-build.shade
+++ b/KoreBuild-dotnet/build/_dotnet-build.shade
@@ -1,6 +1,6 @@
 @{/*
 
-dotnet-compile
+dotnet-build
     Builds a project.
 
 projectFile=''
@@ -11,7 +11,7 @@ configuration=''
 */}
 
 default configuration = 'Debug'
-default compile_options=' ${E("KOREBUILD_DOTNET_COMPILE_OPTIONS")}'
+default build_options=' ${E("KOREBUILD_DOTNET_BUILD_OPTIONS")}'
 
 @{
     var projectFolder=Path.GetDirectoryName(projectFile);
@@ -19,6 +19,6 @@ default compile_options=' ${E("KOREBUILD_DOTNET_COMPILE_OPTIONS")}'
 
     DeleteFolder(projectBin);
 
-    var dotnetArgs=string.Format("compile{0} {1} --configuration {2}", compile_options, projectFolder, configuration);
+    var dotnetArgs=string.Format("build{0} {1} --configuration {2}", build_options, projectFolder, configuration);
     Dotnet(dotnetArgs);
 }

--- a/KoreBuild-dotnet/build/_k-standard-goals.shade
+++ b/KoreBuild-dotnet/build/_k-standard-goals.shade
@@ -169,7 +169,7 @@ default NUGET_FEED = 'https://api.nuget.org/v3/index.json'
 #build-samples target='test' if='Directory.Exists("samples")'
   @{
     var projectFiles = Files.Include("samples/**/project.json").ToList();
-    projectFiles.ForEach(projectFile => DotnetCompile(projectFile, Configuration));
+    projectFiles.ForEach(projectFile => DotnetBuild(projectFile, Configuration));
   }
 
 #make-roslyn-fast
@@ -307,8 +307,8 @@ macro name='Dotnet' command='string'
 macro name='Dotnet' command='string' dotnetDir='string'
     dotnet    
 
-macro name="DotnetCompile" projectFile='string' configuration='string'
-    dotnet-compile
+macro name="DotnetBuild" projectFile='string' configuration='string'
+    dotnet-build
 
 macro name="DotnetPack" projectFile='string' dotnetPackOutputDir='string' configuration='string'
     dotnet-pack


### PR DESCRIPTION
Compile requires all dependencies in the output folder. Build will build the dependencies.

Use build for samples.

cc @pranavkm 