### PR TITLE
Honor KOREBUILD_TEST_SKIPMONO (#353).

### DIFF
--- a/KoreBuild-dotnet/build/_xunit-test.shade
+++ b/KoreBuild-dotnet/build/_xunit-test.shade
@@ -2,6 +2,7 @@ use import="Json"
 use import="Environment"
 
 default NO_PARALLEL_TEST_PROJECTS='${E("NO_PARALLEL_TEST_PROJECTS")}'
+default KOREBUILD_TEST_SKIPMONO='${E("KOREBUILD_TEST_SKIPMONO")}'
 
 @{/*
 
@@ -14,47 +15,50 @@ projectFile=''
 */}
 
 @{
-    var projectText = File.ReadAllText(projectFile);
-    var project = (JsonObject)Json.Deserialize(projectText);
-
-    if (project.Keys.Contains("testRunner"))
+    if (!string.Equals(KOREBUILD_TEST_SKIPMONO, "1") && !string.Equals(KOREBUILD_TEST_SKIPMONO, "true"))
     {
-        var projectFolder = Path.GetDirectoryName(projectFile);
-        var projectName = Path.GetFileName(projectFolder);
+        var projectText = File.ReadAllText(projectFile);
+        var project = (JsonObject)Json.Deserialize(projectText);
 
-        var noParallelTestProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (!string.IsNullOrEmpty(NO_PARALLEL_TEST_PROJECTS))
+        if (project.Keys.Contains("testRunner"))
         {
-            noParallelTestProjects.UnionWith(NO_PARALLEL_TEST_PROJECTS.Split((char)','));
-        }
-        
-        var testArgs = noParallelTestProjects.Contains(projectName) ? " -parallel none" : "";
-            
-        var configs = project.ValueAsJsonObject("frameworks");
-        IEnumerable<string> targetFrameworks = configs == null? 
-            new string[0]: 
-            configs.Keys.Where(k => k.StartsWith("dnx", StringComparison.OrdinalIgnoreCase));
-        
-        var runnerFolder = Path.GetFullPath(Path.Combine(KoreBuildFolderPath, "build", "xunit.runner.console", "tools"));
+            var projectFolder = Path.GetDirectoryName(projectFile);
+            var projectName = Path.GetFileName(projectFolder);
 
-        foreach (var framework in targetFrameworks)
-        {
-            if (!framework.StartsWith("dnxcore"))
+            var noParallelTestProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrEmpty(NO_PARALLEL_TEST_PROJECTS))
             {
-                if (IsLinux)
+                noParallelTestProjects.UnionWith(NO_PARALLEL_TEST_PROJECTS.Split((char)','));
+            }
+
+            var testArgs = noParallelTestProjects.Contains(projectName) ? " -parallel none" : "";
+
+            var configs = project.ValueAsJsonObject("frameworks");
+            IEnumerable<string> targetFrameworks = configs == null?
+                new string[0]:
+                configs.Keys.Where(k => k.StartsWith("dnx", StringComparison.OrdinalIgnoreCase));
+
+            var runnerFolder = Path.GetFullPath(Path.Combine(KoreBuildFolderPath, "build", "xunit.runner.console", "tools"));
+
+            foreach (var framework in targetFrameworks)
+            {
+                if (!framework.StartsWith("dnxcore"))
                 {
-                    // Work around issue with testing in parallel on Mono.
-                    testArgs = " -parallel none";
+                    if (IsLinux)
+                    {
+                        // Work around issue with testing in parallel on Mono.
+                        testArgs = " -parallel none";
+                    }
+
+                    var publishFolder = Path.Combine(projectFolder, ".testPublish", framework);
+                    DotnetPublish(projectFile, publishFolder, framework);
+                    Copy(runnerFolder, publishFolder, "*.*", true);
+
+                    var targetTestDll = projectName + ".dll";
+
+                    var runnerExe = Path.GetFullPath(Path.Combine(publishFolder, "xunit.console.exe"));
+                    ExecClr(runnerExe, targetTestDll + " " + testArgs, publishFolder);
                 }
-
-                var publishFolder = Path.Combine(projectFolder, ".testPublish", framework);
-                DotnetPublish(projectFile, publishFolder, framework);
-                Copy(runnerFolder, publishFolder, "*.*", true);
-                
-                var targetTestDll = projectName + ".dll";
-
-                var runnerExe = Path.GetFullPath(Path.Combine(publishFolder, "xunit.console.exe"));
-                ExecClr(runnerExe, targetTestDll + " " + testArgs, publishFolder);
             }
         }
     }


### PR DESCRIPTION
Nothing needs to be done for `KOREBUILD_TEST_DNXCORE` since the new build doesn't skip tests on CoreCLR on non-Windows platforms.

#353

cc @victorhurdugaci 