### PR TITLE
update dotnet-install script and use beta channel

### DIFF
--- a/KoreBuild-dotnet/build/KoreBuild.cmd
+++ b/KoreBuild-dotnet/build/KoreBuild.cmd
@@ -9,6 +9,9 @@ IF "%NUGET_PATH%"=="" (
 	ECHO Error: NUGET_PATH is not set.
 	EXIT /B 1
 )
+IF "%KOREBUILD_DOTNET_CHANNEL%"=="" (
+    SET KOREBUILD_DOTNET_CHANNEL=beta
+)
 
 IF NOT EXIST Sake  (
     "%NUGET_PATH%" install Sake -ExcludeVersion -Source https://api.nuget.org/v3/index.json -o %~dp0
@@ -30,7 +33,7 @@ IF "%KOREBUILD_SKIP_RUNTIME_INSTALL%"=="1" (
 SET DOTNET_LOCAL_INSTALL_FOLDER=%LOCALAPPDATA%\Microsoft\dotnet\cli
 SET DOTNET_LOCAL_INSTALL_FOLDER_BIN=%DOTNET_LOCAL_INSTALL_FOLDER%\bin
 
-CALL %~dp0dotnet-install.cmd
+CALL %~dp0dotnet-install.cmd -Channel %KOREBUILD_DOTNET_CHANNEL%
 
 ECHO Adding %DOTNET_LOCAL_INSTALL_FOLDER_BIN% to PATH
 SET PATH=%DOTNET_LOCAL_INSTALL_FOLDER_BIN%;%PATH%

--- a/KoreBuild-dotnet/build/KoreBuild.sh
+++ b/KoreBuild-dotnet/build/KoreBuild.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+[ -z "$KOREBUILD_DOTNET_CHANNEL" ] && KOREBUILD_DOTNET_CHANNEL=beta
+
 targets=""
 filename=$0
 while [[ $# > 0 ]]; do
@@ -57,7 +60,7 @@ else
     export DOTNET_HOME=$DOTNET_INSTALL_DIR/share/dotnet/cli
     export KOREBUILD_FOLDER="$(dirname $thisDir)"
     chmod +x $thisDir/dotnet-install.sh
-    $thisDir/dotnet-install.sh
+    $thisDir/dotnet-install.sh --channel $KOREBUILD_DOTNET_CHANNEL
     # ==== Temporary ====
     if ! type dnvm > /dev/null 2>&1; then
         source $thisDir/dnvm.sh


### PR DESCRIPTION
/cc @victorhurdugaci @davidfowl 

This is using the install script from https://github.com/dotnet/cli/pull/1228 optimistically :). If that gets changed before merging I'll update it here.

Both scripts default the `CHANNEL` value to `beta`. But it can be overridden by an environment variable (`CHANNEL` ;))