### PR TITLE
Add `--no-restore` and apply `--quiet` to `dotnet restore`

### DIFF
--- a/KoreBuild-dotnet/build/_dnx-test.shade
+++ b/KoreBuild-dotnet/build/_dnx-test.shade
@@ -2,7 +2,6 @@ use import="Json"
 use import="Environment"
 
 default NO_PARALLEL_TEST_PROJECTS='${E("NO_PARALLEL_TEST_PROJECTS")}'
-default KOREBUILD_TEST_DNXCORE='${E("KOREBUILD_TEST_DNXCORE")}'
 default KOREBUILD_TEST_SKIPMONO='${E("KOREBUILD_TEST_SKIPMONO")}'
 
 @{/*

--- a/KoreBuild-dotnet/build/_k-standard-goals.shade
+++ b/KoreBuild-dotnet/build/_k-standard-goals.shade
@@ -68,7 +68,7 @@ default NUGET_FEED = 'https://api.nuget.org/v3/index.json'
 -// Target order is important because clean-npm-modules may (re)create bin folder.
 #deep-clean .clean-npm-modules .clean-bin-folder description='Clean folders that may cause problems for `git clean`.'
 
-#repo-initialize target='initialize'
+#repo-initialize target='initialize' if='!NoRestore'
   dotnet-restore
 
 #target-dir-clean target='clean'
@@ -207,8 +207,12 @@ default NUGET_FEED = 'https://api.nuget.org/v3/index.json'
      }
    }
 
+#--no-restore
+  @{ NoRestore = true; }
+
 #--quiet
   @{
+    AddToE("KOREBUILD_DOTNET_RESTORE_OPTIONS", "--verbosity minimal");
     AddToE("KOREBUILD_BOWER_INSTALL_OPTIONS", "--quiet");
     AddToE("KOREBUILD_NPM_INSTALL_OPTIONS", "--quiet");
     Quiet = true;
@@ -221,7 +225,7 @@ default NUGET_FEED = 'https://api.nuget.org/v3/index.json'
 
 #--test-dnxcore
   @{
-    E("KOREBUILD_TEST_DNXCORE", "1");
+     Log.Warn("The --test-dnxcore flag is no longer supported. It will be ignored.");
   }
 
 #stylecop if='Directory.Exists("src")'
@@ -230,6 +234,7 @@ default NUGET_FEED = 'https://api.nuget.org/v3/index.json'
 
 functions @{
     private static bool Quiet { get; set; }
+    private static bool NoRestore { get; set; }
 
     string E(string key) { return Environment.GetEnvironmentVariable(key); }
     void E(string key, string value) { Environment.SetEnvironmentVariable(key, value); }


### PR DESCRIPTION
- new `--no-restore` pseudo-target controls whether `dotnet restore` runs at all
- `--quiet` adds `--verbosity minimal` to `dotnet restore` command

nit: clean out dangling `KOREBUILD_TEST_DNXCORE` environment variable
 - `--test-dnxcore` now logs a warning