### PR TITLE
Fix CLI upgrade bug

### DIFF
--- a/KoreBuild-dotnet/build/dotnet-install.ps1
+++ b/KoreBuild-dotnet/build/dotnet-install.ps1
@@ -5,7 +5,7 @@
 
 param(
    [string]$Channel="dev",
-   [string]$version="Latest"
+   [string]$Version="Latest"
 )
 
 $ErrorActionPreference="Stop"
@@ -59,6 +59,8 @@ if (Test-Path $LocalFile)
                 say "You already have the latest version"
                 exit 0
             }
+            $DotNetFileName="dotnet-win-x64.$RemoteVersion.zip"
+            $DotNetUrl="$Feed/$Channel/Binaries/$RemoteVersion"
         }
         elseif ($LocalVersion -eq $Version)
         {

--- a/KoreBuild-dotnet/build/dotnet-install.sh
+++ b/KoreBuild-dotnet/build/dotnet-install.sh
@@ -175,23 +175,28 @@ install_dotnet()
     if [ "$RELINK" = "0" ]; then
         if [ "$FORCE" = "0" ]; then
             # Check if we need to bother
-            local remoteData="$(curl -s https://dotnetcli.blob.core.windows.net/dotnet/$CHANNEL/dnvm/latest.$os.version)"
-            [ $? != 0 ] && say_err "Unable to determine latest version." && return 1
-
-            local remoteVersion=$(IFS="\n" && echo $remoteData | tail -n 1)
-            local remoteHash=$(IFS="\n" && echo $remoteData | head -n 1)
-
             local localVersion=$(tail -n 1 "$installLocation/cli/.version" 2>/dev/null)
             [ -z $localVersion ] && localVersion='<none>'
             local localHash=$(head -n 1 "$installLocation/cli/.version" 2>/dev/null)
 
-            say "Latest Version: $remoteVersion"
-            say "Local Version: $localVersion"
+            if [ "$VERSION" == "Latest" ]; then
+                local remoteData="$(curl -s https://dotnetcli.blob.core.windows.net/dotnet/$CHANNEL/dnvm/latest.$os.version)"
+                [ $? != 0 ] && say_err "Unable to determine latest version." && return 1
 
-            [ "$remoteHash" = "$localHash" ] && say "${green}You already have the latest version.${normal}" && return 0
+                local remoteVersion=$(IFS="\n" && echo $remoteData | tail -n 1)
+                local remoteHash=$(IFS="\n" && echo $remoteData | head -n 1)
 
-            dotnet_url="https://dotnetcli.blob.core.windows.net/dotnet/$CHANNEL/Binaries/$remoteVersion"
-            dotnet_filename="dotnet-$os-x64.$remoteVersion.tar.gz"
+                say "Latest Version: $remoteVersion"
+                say "Local Version: $localVersion"
+
+                [ "$remoteHash" = "$localHash" ] && say "${green}You already have the latest version.${normal}" && return 0
+
+                dotnet_url="https://dotnetcli.blob.core.windows.net/dotnet/$CHANNEL/Binaries/$remoteVersion"
+                dotnet_filename="dotnet-$os-x64.$remoteVersion.tar.gz"
+            elif [ "$localVersion" == "$VERSION" ]; then
+                say "${green}$VERSION is already installed.${normal}"
+                return 0
+            fi
         fi
 
         #This should noop if the directory already exists.

--- a/KoreBuild-dotnet/build/dotnet-install.sh
+++ b/KoreBuild-dotnet/build/dotnet-install.sh
@@ -189,6 +189,9 @@ install_dotnet()
             say "Local Version: $localVersion"
 
             [ "$remoteHash" = "$localHash" ] && say "${green}You already have the latest version.${normal}" && return 0
+
+            dotnet_url="https://dotnetcli.blob.core.windows.net/dotnet/$CHANNEL/Binaries/$remoteVersion"
+            dotnet_filename="dotnet-$os-x64.$remoteVersion.tar.gz"
         fi
 
         #This should noop if the directory already exists.


### PR DESCRIPTION
Before this change, KoreBuild would not pick the correct version when it had to upgrade. The variables used to point to the latest version (in case an upgrade is needed) hadn't been updated before download commences. This fixes that situation and allows the machine to have the latest CLI from the beta channel installed.

@SajayAntony @muratg @cesarbs @pranavkm @victorhurdugaci 