### PR TITLE
Remove aspnet.xunit from Universe builds

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -831,7 +831,6 @@ functions
                 "DataProtection",
                 "HttpAbstractions",
                 "Testing",
-                "aspnet.xunit",
                 "Microsoft.Data.Sqlite",
                 "Caching",
                 "Razor",


### PR DESCRIPTION
cc @victorhurdugaci  \ @muratg . We'll trigger it off of DNX and eventually stop building it. I'll follow up with a change to Coherence to pick up this package in addition to UniverseCoherence.