### PR TITLE
Save the .build folder during build

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -166,6 +166,16 @@ var buildTarget = "compile"
         var universeBuild = Path.Combine(universeArtifacts, "build");
         var packagesPublishDir = Path.Combine(Directory.GetCurrentDirectory(), ".nuget", "publishDir");
 
+        // Snapshot the .build folder
+        if (!IsLinux)
+        {
+            Exec("cmd", "/C xcopy /S/Q/I/Y .build " + Path.Combine(universeArtifacts, ".build"), "");
+        }
+        else
+        {
+            CopyFolder(".build", Path.Combine(universeArtifacts, ".build"), true);
+        }
+
         var blockLogger = Log as IBlockLogger;
         var commits = new ConcurrentDictionary<string, string>();
         var threads = int.Parse(Environment.GetEnvironmentVariable("UNIVERSE_THREADS") ?? "4");


### PR DESCRIPTION
Save the entire `.build` folder during the big universe build. That will give us the CLI version used plus it can be used to reproduce the build.

@pranavkm please review

cc @Eilon, @DamianEdwards for ask-mode