### PR TITLE
`StopOnFirstFailure` when doing repository builds

### DIFF
--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -41,6 +41,7 @@
     <MSBuild
       Projects="@(BatchedRepository)"
       BuildInParallel="$(BatchBuilds)"
+      StopOnFirstFailure="true"
       Targets="_BuildRepository"
       Properties="BuildGroup=%(BatchedRepository.BuildGroup)" />
   </Target>


### PR DESCRIPTION
- avoids MSBuild continuing past failed repositories in sequential builds
- ignored when building in parallel (unfortunately)