### PR TITLE
Enabled a way to passing in additional build arguments to individual …

### DIFF
--- a/build/RepositoryBuild.targets
+++ b/build/RepositoryBuild.targets
@@ -48,7 +48,7 @@
 
   <Target Name="_BuildRepository" DependsOnTargets="_PinVersions">
     <PropertyGroup>
-      <BuildArguments>$(_RepositoryBuildTargets) /p:BuildNumber=$(BuildNumber) /p:Configuration=$(Configuration)</BuildArguments>
+      <BuildArguments>$(_RepositoryBuildTargets) $(RepositoryBuildArguments)</BuildArguments>
       <RepositoryArtifactsRoot>$(BuildRepositoryRoot)artifacts</RepositoryArtifactsRoot>
       <RepositoryArtifactsBuildDirectory>$(RepositoryArtifactsRoot)\build\</RepositoryArtifactsBuildDirectory>
       <RepositoryArtifactsMSBuildDirectory>$(RepositoryArtifactsRoot)\msbuild\</RepositoryArtifactsMSBuildDirectory>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -110,11 +110,13 @@
      DependsOnTargets="_FilterRepositories;_FindDotNetPath;_GenerateRestoreGraphSpecs;_GenerateBuildGraph;_UpdateNuGetConfig;_CreateRepositoriesListWithCommits">
 
     <PropertyGroup>
+      <!-- If there are duplicate properties, the properties which are defined later in the order would override the earlier ones -->
+      <RepositoryBuildArguments>$(RepositoryBuildArguments) /p:BuildNumber=$(BuildNumber) /p:Configuration=$(Configuration)</RepositoryBuildArguments>
+
       <_BuildRepositoryProperties>
         UniverseBuildDir=$(BuildDir);
         UniverseMSBuildDir=$(ArtifactsDir)msbuild;
         BuildInParallel=$(BuildInParallel);
-        BuildNumber=$(BuildNumber);
         Configuration=$(Configuration);
         DotNetPath=$(DotNetPath);
         KoreBuildDirectory=$(MSBuildProjectDirectory)\;
@@ -124,6 +126,7 @@
         _CloneRepositoryRoot=$(_CloneRepositoryRoot);
         _DependencyPackagesDirectory=$(_DependencyPackagesDirectory);
         _RepositoryBuildTargets=$(_RepositoryBuildTargets);
+        RepositoryBuildArguments=$(RepositoryBuildArguments);
         _RestoreGraphSpecsDirectory=$(_RestoreGraphSpecsDirectory);
         PackagePublisherPath=$(PackagePublisherNetCoreApp)
       </_BuildRepositoryProperties>


### PR DESCRIPTION
…repositories being built

Related to https://github.com/aspnet/CoreCLR/issues/237

Idea is to supply `/p:RepositoryBuildArguments="/p:EnableApiCheck=false"` to TeamCity's `config.BuildArguments`

#### Example: ####

- Universe's msbuild.rsp file:
```
/nologo
/m
/p:RepositoryRoot="C:\github\universe/"
""
/clp:Summary
"C:\github\universe\.build/KoreBuild.proj"
"/p:CompileOnly=true"
"/p:ShallowClone=true"
"/p:RepositoryBuildArguments=/p:EnableApiCheck=false"
```

- Options repo's msbuild.rsp file:
```
/nologo
/m
/p:RepositoryRoot="C:\github\universe\.r\Options/"
""
/clp:Summary
"C:\github\universe\.r\Options\.build/KoreBuild.proj"
"/t:Package"
"/t:VerifyPackages"
"/p:EnableApiCheck=false"
"/p:BuildNumber=t004bb5298"
"/p:Configuration=Debug"

```