### PR TITLE
Respect ExcludeSolutions when calculating the build graph

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -110,13 +110,19 @@
      DependsOnTargets="_PrepareRepositories;_CreateRepositoriesListWithCommits;_UpdateNuGetConfig;_GenerateBuildGraph;_BuildRepositories" />
 
   <Target Name="_PrepareRestoreGraphSpecs" DependsOnTargets="_PrepareRepositories">
-    <ItemGroup>
-      <Solution Include="$(_CloneRepositoryRoot)%(Repository.Identity)\*.sln">
-        <Repository>%(Repository.Identity)</Repository>
-      </Solution>
 
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="ResolveSolutions"
+             Properties="RepositoryRoot=$(_CloneRepositoryRoot)%(Repository.Identity)\"
+             ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="TargetOutputs" ItemName="Solution" />
+    </MSBuild>
+
+    <Error Text="No solutions were found in '$(_CloneRepositoryRoot)'" Condition="@(Solution->Count()) == 0" />
+
+    <ItemGroup>
       <Solution>
-        <AdditionalProperties>RestoreGraphOutputPath=$(_RestoreGraphSpecsDirectory)%(Solution.Repository)\%(Solution.FileName)%(Solution.Extension).json</AdditionalProperties>
+        <AdditionalProperties>RestoreGraphOutputPath=$(_RestoreGraphSpecsDirectory)$([System.IO.Path]::GetFileName('$([System.IO.Path]::GetDirectoryName(%(FullPath)))'))\%(Solution.FileName)%(Solution.Extension).json</AdditionalProperties>
       </Solution>
 
       <GraphSpecInputs Include="

--- a/build/tasks/BuildGraph/DependencyGraphSpecProvider.cs
+++ b/build/tasks/BuildGraph/DependencyGraphSpecProvider.cs
@@ -15,6 +15,12 @@ namespace RepoTools.BuildGraph
         public DependencyGraphSpec GetDependencyGraphSpec(string repositoryName, string solutionPath)
         {
             var outputFile = Path.Combine(_packageSpecDirectory, repositoryName, Path.GetFileName(solutionPath) + ".json");
+
+            if (!File.Exists(outputFile))
+            {
+                return null;
+            }
+
             return DependencyGraphSpec.Load(outputFile);
         }
     }

--- a/build/tasks/BuildGraph/Repository.cs
+++ b/build/tasks/BuildGraph/Repository.cs
@@ -56,6 +56,11 @@ namespace RepoTools.BuildGraph
             foreach (var file in solutionFiles)
             {
                 var spec = provider.GetDependencyGraphSpec(name, file);
+                if (spec == null)
+                {
+                    continue;
+                }
+
                 var projects = spec.Projects.OrderBy(p => p.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference ? 0 : 1);
                 foreach (var specProject in projects)
                 {


### PR DESCRIPTION
The build graph computation was ignoring the ExcludeSolutions item group. For repos with multiple solutions like EF and Mvc, this can cause incorrect an repo graph calculation if the excluded solution has PackageReferences that violate the build graph chain.