### PR TITLE
Add ANCM

### DIFF
--- a/build/Repositories.props
+++ b/build/Repositories.props
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Repository Include="Antiforgery" Commit="" CloneUrl="git@github.com:aspnet/%(Identity)" />
+    <Repository Include="AspNetCoreModule" Commit="" CloneUrl="git@github.com:aspnet/%(Identity)" />
     <Repository Include="AzureIntegration" Commit="" CloneUrl="git@github.com:aspnet/%(Identity)" />
     <Repository Include="BasicMiddleware" Commit="" CloneUrl="git@github.com:aspnet/%(Identity)" />
     <Repository Include="BrowserLink" Commit="" CloneUrl="git@github.com:aspnet/%(Identity)" />


### PR DESCRIPTION
Fixes aspnet/CoreCLR#253. Since we're taking over development on AspNetCoreModule we should build it in Universe instead of in the CoreCLR mirror.