### PR TITLE
Upgrade xunit to 2.3.0-beta4

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -19,8 +19,11 @@
     <ExternalDependency Include="Microsoft.NET.Test.Sdk" Version="15.3.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="Moq" Version="4.7.49" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="Newtonsoft.Json" Version="10.0.1" Source="$(DefaultNuGetFeed)"/>
-    <ExternalDependency Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" Source="$(DefaultNuGetFeed)"/>
-    <ExternalDependency Include="xunit" Version="2.3.0-beta3-build3705" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="xunit.analyzers" Version="0.6.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="xunit.assert" Version="2.3.0-beta4-build3742" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="xunit.core" Version="2.3.0-beta4-build3742" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="xunit" Version="2.3.0-beta4-build3742" Source="$(DefaultNuGetFeed)"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Also, expands the list of xunit packages to include commonly used sub-packages, such as xunit.core.