### PR TITLE
Expand the list of external dependencies 

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -15,12 +15,40 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ExternalDependency Include="BenchmarkDotNet" Version="0.10.3" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="BenchmarkDotNet" Version="0.10.9" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="FSharp.Core" Version="4.2.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="FSharp.NET.Sdk" Version="1.0.5" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Google.Protobuf" Version="3.1.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.AspNet.WebApi.Client" Version="5.2.2" Source="$(AspNetCoreFeed)"/>
+    <ExternalDependency Include="Microsoft.Azure.KeyVault" Version="2.3.2" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Build.Framework" Version="15.3.309" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Build.Tasks.Core" Version="15.3.309" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Build.Utilities.Core" Version="15.3.309" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Build" Version="15.3.309" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="Microsoft.CSharp" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.14.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="Microsoft.NET.Test.Sdk" Version="15.3.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Owin.Security.Cookies" Version="3.0.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Owin.Security" Version="3.0.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Owin.Testing" Version="3.0.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Owin" Version="3.0.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Microsoft.Web.Xdt" Version="1.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="Moq" Version="4.7.49" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="MsgPack.Cli" Version="0.9.0-beta2" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Newtonsoft.Json.Bson" Version="1.0.1" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="Newtonsoft.Json" Version="10.0.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Remotion.Linq" Version="2.2.0-alpha-002" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Serilog.Extensions.Logging" Version="1.4.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="Serilog.Sinks.File" Version="3.2.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="SQLitePCLRaw.bundle_green" Version="1.1.8" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="SQLitePCLRaw.core" Version="1.1.8" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="StackExchange.Redis.StrongName" Version="1.2.4" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="StreamJsonRpc" Version="1.1.92" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Buffers" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.CodeDom" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Collections.Immutable" Version="1.4.0" Source="$(DefaultNuGetFeed)"/>
@@ -34,6 +62,7 @@
     <ExternalDependency Include="System.Configuration.ConfigurationManager" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Data.SqlClient" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="System.Interactive.Async" Version="3.1.1" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.IO.FileSystem.AccessControl" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.IO.Packaging" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.IO.Pipes.AccessControl" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
@@ -41,10 +70,13 @@
     <ExternalDependency Include="System.Json" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Net.Http.WinHttpHandler" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Numerics.Vectors" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="System.Reactive.Linq" Version="3.1.1" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Reflection.DispatchProxy" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Reflection.Metadata" Version="1.5.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Reflection.TypeExtensions" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="System.Reflection.Emit" Version="4.3.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Security.AccessControl" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Security.Cryptography.Cng" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Security.Cryptography.Pkcs" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
@@ -59,6 +91,8 @@
     <ExternalDependency Include="System.Threading.Tasks.Dataflow" Version="4.8.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.Threading.Tasks.Extensions" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="System.ValueTuple" Version="4.4.0" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="WindowsAzure.Storage" Version="8.1.4" Source="$(DefaultNuGetFeed)"/>
+    <ExternalDependency Include="xunit.abstractions" Version="2.0.1" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="xunit.analyzers" Version="0.6.1" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="xunit.assert" Version="2.3.0-beta4-build3742" Source="$(DefaultNuGetFeed)"/>
     <ExternalDependency Include="xunit.core" Version="2.3.0-beta4-build3742" Source="$(DefaultNuGetFeed)"/>


### PR DESCRIPTION
This includes almost everything referenced from an ASP.NET Core project using the versions as they currently stand in the dev branch.

There are a few to be added for a few repos that have special considerations, such as EF (needs to reference EF Core 1.x) and EF/MVC/Scaffolding (they reference roslyn packages). I'll address those later when we convert those repos to lineups.

cc @Eilon - you may be interested in seeing this list...