### PR TITLE
Produce separate reference package for runtime store generation

### DIFF
--- a/build/RuntimeStore.targets
+++ b/build/RuntimeStore.targets
@@ -33,7 +33,7 @@
     <Copy SourceFiles="@(AllMetapackageFiles)" DestinationFolder="$(MetapackageWorkDirectory)\%(RecursiveDir)" />
     <Copy SourceFiles="$(_SrcDirectory)Directory.Build.props" DestinationFolder="$(_WorkRoot)" />
 
-    <!-- Generate RS.Reference project -->
+    <!-- Add references to project -->
     <RepoTasks.AddMetapackageReferences
       ReferencePackagePath="$(MetapackageWorkDirectory)Microsoft.AspNetCore.All.csproj"
       BuildArtifacts="@(ArtifactInfo)"
@@ -58,10 +58,44 @@
     <Copy SourceFiles="@(AllMetapackageNupkgFile)" DestinationFolder="$(BuildDir)" />
   </Target>
 
-  <Target Name="_PrepareRuntimeStoreBuildAssets">
+  <Target Name="BuildRSReferencesPackage" DependsOnTargets="ResolveRepoInfo">
     <!-- Clear working directory -->
     <RemoveDir Directories="$(_WorkRoot)" />
 
+    <!-- Move to working dir -->
+    <PropertyGroup>
+      <RSReferencesWorkDirectory>$(_WorkRoot)RS.References\</RSReferencesWorkDirectory>
+    </PropertyGroup>
+
+    <Copy SourceFiles="$(_TemplatesDirectory)RS.References\RS.References.csproj" DestinationFolder="$(RSReferencesWorkDirectory)" />
+    <Copy SourceFiles="$(_SrcDirectory)Directory.Build.props" DestinationFolder="$(_WorkRoot)" />
+
+    <!-- Generate RS.Reference project -->
+    <RepoTasks.AddRSReferences
+      ReferencePackagePath="$(RSReferencesWorkDirectory)RS.References.csproj"
+      BuildArtifacts="@(ArtifactInfo)"
+      PackageArtifacts="@(PackageArtifact)"
+      ExternalDependencies="@(ExternalDependency)" />
+
+    <!-- Set _Target=Restore so the project will be re-evaluated to include Internal.AspNetCore.Sdk MSBuild properties on the next step. -->
+    <MSBuild Projects="$(RSReferencesWorkDirectory)RS.References.csproj"
+      Targets="Restore"
+      Properties="Configuration=$(Configuration);DotNetRestoreSourcePropsPath=$(GeneratedRestoreSourcesPropsPath);AspNetUniverseBuildOffline=true;_Target=Restore" />
+
+    <!-- Pack -->
+    <MSBuild Projects="$(RSReferencesWorkDirectory)RS.References.csproj"
+      Targets="Pack"
+      Properties="Configuration=$(Configuration);DotNetRestoreSourcePropsPath=$(GeneratedRestoreSourcesPropsPath);AspNetUniverseBuildOffline=true" />
+
+    <!-- Copy to output directory -->
+    <ItemGroup>
+      <RSReferenceNupkgFile Include="$(RSReferencesWorkDirectory)**\*.nupkg" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(RSReferenceNupkgFile)" DestinationFolder="$(BuildDir)" />
+  </Target>
+
+  <Target Name="_PrepareRuntimeStoreBuildAssets">
     <!-- Copy and update build assets -->
     <Copy SourceFiles="$(_TemplatesDirectory)RS.Manifest\RS.Manifest.csproj" DestinationFiles="$(_WorkRoot)RS.Manifest.csproj" />
 
@@ -91,7 +125,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="BuildRuntimeStore" DependsOnTargets="_ResolveRuntimeStoreRID;_PrepareRuntimeStoreBuildAssets;_ResolveCurrentSharedFrameworkVersion">
+  <Target Name="BuildRuntimeStore" DependsOnTargets="BuildRSReferencesPackage;_ResolveRuntimeStoreRID;_PrepareRuntimeStoreBuildAssets;_ResolveCurrentSharedFrameworkVersion">
     <PropertyGroup>
       <__ComposeStoreProps />
       <_ComposeStoreProps>$(_ComposeStoreProps);$(_RsManifestProps)</_ComposeStoreProps>

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -2,6 +2,8 @@
   <ItemDefinitionGroup>
     <PackageArtifact>
       <Metapackage>false</Metapackage>
+      <HostingStartup>false</HostingStartup>
+      <RuntimeStore>false</RuntimeStore>
       <LZMA>false</LZMA>
       <LZMATools>false</LZMATools>
     </PackageArtifact>
@@ -10,52 +12,52 @@
   <ItemGroup>
     <PackageArtifact Include="Microsoft.AspNet.Identity.AspNetCoreCompat" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.All" Category="ship" LZMA="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Category="ship" Metapackage="hostingstartup" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Abstractions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Cookies" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Core" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Facebook" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Google" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.JwtBearer" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OAuth" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Twitter" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Category="ship" Metapackage="hostingstartup" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Category="ship" RuntimeStore="true" HostingStartup="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Cookies" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Core" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Facebook" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Google" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.JwtBearer" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OAuth" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Twitter" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Category="ship" Metapackage="true" RuntimeStore="true" HostingStartup="true" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Buffering" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Certificates.Configuration.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.ChunkingCookieManager.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.CookiePolicy" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Cors" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.Internal" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Abstractions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Extensions" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.CookiePolicy" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Cors" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.Internal" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Extensions" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.Redis" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.DataProtection.SystemWeb" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.DataProtection" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Elm" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics.Identity.Service" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Abstractions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Diagnostics" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Hosting.WindowsServices" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Hosting" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Abstractions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Extensions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http.Features" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Http" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.HttpOverrides" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Hosting" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Http.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Http.Extensions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Http.Features" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Http" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.HttpOverrides" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Identity.Service.Abstractions" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Identity.Service.AzureKeyVault" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Identity.Service.Core" Category="noship" />
@@ -65,88 +67,88 @@
     <PackageArtifact Include="Microsoft.AspNetCore.Identity.Service.Specification.Tests" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Identity.Service" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Identity.Specification.Tests" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Identity" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Localization.Routing" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Localization" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.MiddlewareAnalysis" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Abstractions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Core" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Cors" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Localization" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.RazorPages" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.TagHelpers" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Identity" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Localization.Routing" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Localization" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.MiddlewareAnalysis" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Core" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Cors" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Localization" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Razor" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.RazorPages" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.TagHelpers" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.Testing" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Mvc" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Mvc" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.NodeServices.Sockets" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.NodeServices" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Owin" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.NodeServices" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Owin" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Proxy" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.RangeHelper.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Razor.Language" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Razor.Runtime" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Razor.Language" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Razor.Runtime" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Razor.TagHelpers.Testing.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Razor" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCompression" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Rewrite" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Routing.Abstractions" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Razor" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCaching" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.ResponseCompression" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Rewrite" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Routing.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Routing.DecisionTree.Sources" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Routing" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.HttpSys" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IISIntegration" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Routing" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.HttpSys" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.IISIntegration" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Core" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Https" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Core" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Https" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.Session" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SpaServices" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Session" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.SpaServices" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.SpaTemplates" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.StaticFiles" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.StaticFiles" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.TestHost" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebSockets" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebUtilities" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.AspNetCore.WebSockets" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.WebUtilities" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.CodeAnalysis.Razor.Workspaces" Category="shipoob" />
-    <PackageArtifact Include="Microsoft.CodeAnalysis.Razor" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.CodeAnalysis.Razor" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.CodeAnalysis.Remote.Razor" Category="shipoob" />
     <PackageArtifact Include="Microsoft.DotNet.Web.Client.ItemTemplates" Category="shipoob" />
     <PackageArtifact Include="Microsoft.DotNet.Web.ItemTemplates" Category="shipoob" />
     <PackageArtifact Include="Microsoft.DotNet.Web.ProjectTemplates.2.0" Category="shipoob" />
     <PackageArtifact Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Category="shipoob" />
-    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Design" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.EntityFrameworkCore.InMemory" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Design" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.EntityFrameworkCore.InMemory" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests" Category="ship" />
     <PackageArtifact Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Category="ship" />
-    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Relational" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Relational" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.EntityFrameworkCore.Specification.Tests" Category="ship" />
-    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Sqlite" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.EntityFrameworkCore.SqlServer" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Sqlite" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.EntityFrameworkCore.SqlServer" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Category="ship" LZMATools="true" />
-    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Tools" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.EntityFrameworkCore" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.Hosting.Abstractions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.Identity.Core" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.Identity.Stores" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.Localization.Abstractions" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.Extensions.Localization" Category="ship" Metapackage="true" />
-    <PackageArtifact Include="Microsoft.Net.Http.Headers" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.EntityFrameworkCore.Tools" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.EntityFrameworkCore" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.Extensions.Hosting.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.Extensions.Identity.Core" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.Extensions.Identity.Stores" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.Extensions.Localization.Abstractions" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.Extensions.Localization" Category="ship" Metapackage="true" RuntimeStore="true"/>
+    <PackageArtifact Include="Microsoft.Net.Http.Headers" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.Owin.Security.Interop" Category="ship" />
     <PackageArtifact Include="Microsoft.VisualStudio.LanguageServices.Razor" Category="shipoob" />
-    <PackageArtifact Include="Microsoft.VisualStudio.Web.BrowserLink" Category="ship" Metapackage="true" />
+    <PackageArtifact Include="Microsoft.VisualStudio.Web.BrowserLink" Category="ship" Metapackage="true" RuntimeStore="true"/>
     <PackageArtifact Include="Microsoft.VisualStudio.Web.CodeGeneration.Contracts" Category="ship" />
     <PackageArtifact Include="Microsoft.VisualStudio.Web.CodeGeneration.Core" Category="ship" />
     <PackageArtifact Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Category="ship" LZMA="true" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -14,6 +14,10 @@
       <Mirror>false</Mirror>
       <!-- When true, this dependency will be included in the metapackage. -->
       <Metapackage>false</Metapackage>
+      <!-- When true, this dependency will be included in the runtime store. -->
+      <RuntimeStore>false</RuntimeStore>
+      <!-- When true, this dependency will be used to generate a deps.json for hosting startup that will be included in the runtime store. -->
+      <HostingStartup>false</HostingStartup>
       <!-- When true, this dependency will be included in the LZMA. -->
       <LZMA>false</LZMA>
       <!-- When true, this tool dependency will be included in the metapackage. -->
@@ -293,46 +297,46 @@ not building again in this patch.
 
   <!-- Shipped dependencies from previous builds -->
   <ItemGroup>
-    <ExternalDependency Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.AspNetCore.JsonPatch" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Data.Sqlite" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Data.Sqlite.Core" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Caching.Redis" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Caching.SqlServer" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Configuration.Xml" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.DiagnosticAdapter" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.FileProviders.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.FileProviders.Composite" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Logging" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Logging.Configuration" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Logging.EventSource" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.ObjectPool" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Options" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.Primitives" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
-    <ExternalDependency Include="Microsoft.Extensions.WebEncoders" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" />
+    <ExternalDependency Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.AspNetCore.JsonPatch" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Data.Sqlite" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Data.Sqlite.Core" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Caching.Redis" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Caching.SqlServer" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Configuration.Xml" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.DiagnosticAdapter" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.FileProviders.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.FileProviders.Composite" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Logging" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Logging.Configuration" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Logging.EventSource" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.ObjectPool" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Options" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.Primitives" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
+    <ExternalDependency Include="Microsoft.Extensions.WebEncoders" Version="2.0.0" Source="$(DefaultNuGetFeed)" Metapackage="true" RuntimeStore="true"/>
     <ExternalDependency Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" Source="$(DefaultNuGetFeed)" LZMATools="true" />
     <ExternalDependency Include="Microsoft.Extensions.Caching.SqlConfig.Tools" Version="2.0.0" Source="$(DefaultNuGetFeed)" LZMATools="true" />
     <ExternalDependency Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" Source="$(DefaultNuGetFeed)" LZMATools="true" />

--- a/build/tasks/AddRSReferences.cs
+++ b/build/tasks/AddRSReferences.cs
@@ -10,7 +10,7 @@ using RepoTasks.Utilities;
 
 namespace RepoTasks
 {
-    public class AddMetapackageReferences : Task
+    public class AddRSReferences : Task
     {
         [Required]
         public string ReferencePackagePath { get; set; }
@@ -27,8 +27,8 @@ namespace RepoTasks
         public override bool Execute()
         {
             // Parse input
-            var metapackageArtifacts = PackageArtifacts.Where(p => p.GetMetadata("Metapackage") == "true");
-            var externalArtifacts = ExternalDependencies.Where(p => p.GetMetadata("Metapackage") == "true");
+            var runtimeStoreArtifacts = PackageArtifacts.Where(p => p.GetMetadata("RuntimeStore") == "true");
+            var externalArtifacts = ExternalDependencies.Where(p => p.GetMetadata("RuntimeStore") == "true");
             var buildArtifacts = BuildArtifacts.Select(ArtifactInfo.Parse)
                 .OfType<ArtifactInfo.Package>()
                 .Where(p => !p.IsSymbolsArtifact);
@@ -41,9 +41,9 @@ namespace RepoTasks
 
             // Items
             var itemGroupElement = xmlDoc.CreateElement("ItemGroup");
-            Log.LogMessage(MessageImportance.High, $"Metapackage will include the following packages");
+            Log.LogMessage(MessageImportance.High, $"Runtime store will include the following packages");
 
-            foreach (var package in metapackageArtifacts)
+            foreach (var package in runtimeStoreArtifacts)
             {
                 var packageName = package.ItemSpec;
                 var packageVersion = buildArtifacts

--- a/build/tasks/RepoTasks.tasks
+++ b/build/tasks/RepoTasks.tasks
@@ -11,6 +11,7 @@
   <UsingTask TaskName="RepoTasks.VerifyCoherentVersions" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="RepoTasks.AddMetapackageReferences" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="RepoTasks.AddArchiveReferences" AssemblyFile="$(_RepoTaskAssembly)" />
+  <UsingTask TaskName="RepoTasks.AddRSReferences" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="RepoTasks.ResolveHostingStartupPackages" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="RepoTasks.TrimDeps" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="RepoTasks.CreateCommonManifest" AssemblyFile="$(_RepoTaskAssembly)" />

--- a/build/tasks/ResolveHostingStartupPackages.cs
+++ b/build/tasks/ResolveHostingStartupPackages.cs
@@ -21,7 +21,7 @@ namespace RepoTasks
         public override bool Execute()
         {
             // Parse input
-            var hostingStartupArtifacts = PackageArtifacts.Where(p => p.GetMetadata("Metapackage") == "hostingstartup");
+            var hostingStartupArtifacts = PackageArtifacts.Where(p => p.GetMetadata("HostingStartup") == "true");
             HostingStartupArtifacts = BuildArtifacts.Where(p => hostingStartupArtifacts.Any(h => h.GetMetadata("Identity") == p.GetMetadata("PackageId"))).ToArray();
 
             return true;

--- a/build/tools/templates/RS.Manifest/RS.Manifest.csproj
+++ b/build/tools/templates/RS.Manifest/RS.Manifest.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-   <PackageReference Include="Microsoft.AspNetCore.All" Version="$(MicrosoftAspNetCoreAllPackageVersion)" />
+   <PackageReference Include="RS.References" Version="$(PackageVersion)" />
   </ItemGroup>
 
   <Target Name="GetPackageDefinitions" Returns="@(_PackageDefinitions)">

--- a/build/tools/templates/RS.References/RS.References.csproj
+++ b/build/tools/templates/RS.References/RS.References.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''"/>
+
+  <PropertyGroup>
+    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND '$(AspNetUniverseBuildOffline)' != 'true' ">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+    </RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
+      $(RestoreSources);
+      https://api.nuget.org/v3/index.json;
+    </RestoreSources>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
There is a lot of code duplication here. For example BuildAllMetapackage and BuildRSReferencePackage targets uses mostly the same logic and can be cleaned up. Same with the Add*References.cs build tasks. This change will also allow us to avoid building then unpacking and repacking the .All metapackage. These changes will follow in a cleanup PR later (I'll file an issue) but I want to do the minimal amount of required work for now to get the builds running.