### PR TITLE
Set DotNetAdditionalRestoreSources on all ExternalDependency items

### DIFF
--- a/build/external-dependencies.props
+++ b/build/external-dependencies.props
@@ -384,7 +384,7 @@
 
   <ItemGroup Condition="'$(DotNetAdditionalRestoreSources)'!=''">
     <ExternalDependency
-      Update="@(ExternalDependency->WithMetadataValue('Source', '$(DotNetCoreFeed)'));@(ExternalDependency->WithMetadataValue('Source', '$(RoslynFeed)'))"
+      Update="@(ExternalDependency)"
       Source="$(DotNetAdditionalRestoreSources);%(ExternalDependency.Source)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
cc @dagood 

Other assets, not just those from dotnet-core/roslyn, may come from DotNetAdditionalRestoreSources  in an orchestrated build