### PR TITLE
Change output of sharedfx build to match feed layout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.trimTrailingWhitespace": true,
+    "files.associations": {
+        "*.*proj": "xml",
+        "*.props": "xml",
+        "*.targets": "xml"
+    }
+}

--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -48,8 +48,8 @@
 
     <PropertyGroup>
       <SharedFxWorkDirectory>$(_WorkRoot)SharedFx\</SharedFxWorkDirectory>
-      <SharedFxOutputDirectory>$(_WorkRoot)Publish\</SharedFxOutputDirectory>
-      <SharedFxPublishDirectory>$(SharedFxOutputDirectory)shared\Microsoft.AspNetCore.All\$(PackageVersion)\</SharedFxPublishDirectory>
+      <SharedFxIntermediateOutputPath>$(_WorkRoot)Publish\</SharedFxIntermediateOutputPath>
+      <SharedFxPublishDirectory>$(SharedFxIntermediateOutputPath)shared\Microsoft.AspNetCore.All\$(PackageVersion)\</SharedFxPublishDirectory>
 
       <_SharedFxProps>Configuration=$(Configuration);RuntimeIdentifier=$(SharedFxRID)</_SharedFxProps>
       <_SharedFxProps>$(_SharedFxProps);RuntimeFrameworkVersion=$(MicrosoftNETCoreApp21PackageVersion)</_SharedFxProps>
@@ -122,15 +122,31 @@
       Lines="@(VersionLines)"
       Overwrite="true" />
 
+    <!--
+      Used by the downloader scripts when pulling from a 'channel' instead of a specific version.
+      The second line must be the package version.
+      See dotnet-install.ps1/sh.
+    -->
+
+    <WriteLinesToFile
+      File="$(SharedFxOutputPath)latest.aspnetcore.version"
+      Lines="@(VersionLines)"
+      Overwrite="true" />
+
+    <GenerateSvgBadge
+      OutputPath="$(SharedFxOutputPath)$(SharedFxInstallerName)-$(SharedFxRID)-version-badge.svg"
+      Label="version"
+      Value="$(PackageVersion)" />
+
     <ItemGroup>
-      <OutputZipFiles Include="$(SharedFxOutputDirectory)**\*" />
+      <OutputZipFiles Include="$(SharedFxIntermediateOutputPath)**\*" />
     </ItemGroup>
 
     <!-- Create archive -->
     <ZipArchive
-      File="$(ArtifactsDir)$(SharedFxInstallerName)-$(PackageVersion)-$(SharedFxRID).zip"
+      File="$(SharedFxOutputPath)$(SharedFxInstallerName)-$(PackageVersion)-$(SharedFxRID).zip"
       SourceFiles="@(OutputZipFiles)"
-      WorkingDirectory="$(SharedFxOutputDirectory)"
+      WorkingDirectory="$(SharedFxIntermediateOutputPath)"
       Overwrite="true"/>
   </Target>
 </Project>

--- a/build/Templating.targets
+++ b/build/Templating.targets
@@ -13,7 +13,7 @@
         Configuration=$(Configuration);
         IsFinalBuild=$(IsFinalBuild);
       </TemplateProjProperties>
-      <TemplateProjTargets>Restore;Compile;Package</TemplateProjTargets>
+      <TemplateProjTargets>CleanArtifacts;Restore;Compile;Package</TemplateProjTargets>
       <TemplateProjTargets Condition="'$(SkipTests)' != 'true'">
         $(TemplateProjTargets);
         Test;

--- a/build/external-dependencies.props
+++ b/build/external-dependencies.props
@@ -196,10 +196,11 @@
   <PropertyGroup>
     <AspNetCoreToolsFeed>https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json</AspNetCoreToolsFeed>
   </PropertyGroup>
+
   <ItemGroup>
-    <ExternalDependency Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkPackageVersion)" Source="$(AspNetCoreToolsFeed)" Private="true" />
-    <ExternalDependency Include="Internal.AspNetCore.SiteExtension.Sdk" Version="$(InternalAspNetCoreSiteExtensionSdkPackageVersion)" Source="$(AspNetCoreToolsFeed)" Private="true" />
-    <ExternalDependency Include="Microsoft.AspNetCore.BuildTools.ApiCheck" Version="$(MicrosoftAspNetCoreBuildToolsApiCheckPackageVersion)" Source="$(AspNetCoreToolsFeed)" Private="true" />
+    <ExternalDependency Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkPackageVersion)" Source="$(KoreBuildBundledPackageFolder);$(AspNetCoreToolsFeed)" Private="true" />
+    <ExternalDependency Include="Internal.AspNetCore.SiteExtension.Sdk" Version="$(InternalAspNetCoreSiteExtensionSdkPackageVersion)" Source="$(KoreBuildBundledPackageFolder);$(AspNetCoreToolsFeed)" Private="true" />
+    <ExternalDependency Include="Microsoft.AspNetCore.BuildTools.ApiCheck" Version="$(MicrosoftAspNetCoreBuildToolsApiCheckPackageVersion)" Source="$(KoreBuildBundledPackageFolder);$(AspNetCoreToolsFeed)" Private="true" />
   </ItemGroup>
   <!-- ASP.NET Core Module -->
   <PropertyGroup>

--- a/build/repo.props
+++ b/build/repo.props
@@ -10,7 +10,8 @@
     <IsFinalBuild Condition="'$(IsFinalBuild)' == ''">false</IsFinalBuild>
 
     <SubmoduleRoot>$(RepositoryRoot)modules\</SubmoduleRoot>
-    <LineupBuildDir>$(ArtifactsDir)lineups\</LineupBuildDir>
+    <LineupBuildDir>$([MSBuild]::NormalizeDirectory($(ArtifactsDir)))lineups\</LineupBuildDir>
+    <SharedFxOutputPath>$([MSBuild]::NormalizeDirectory($(ArtifactsDir)))assets\Runtime\$(PackageVersion)\</SharedFxOutputPath>
 
     <DependencyPackageDir>$(RepositoryRoot).deps\build\</DependencyPackageDir>
     <DependencyMirrorPackageDir>$(RepositoryRoot).deps\mirror\</DependencyMirrorPackageDir>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -23,6 +23,7 @@
     <CompileDependsOn>$(CompileDependsOn);BuildRepositories</CompileDependsOn>
     <PackageDependsOn Condition="'$(TestOnly)' != 'true'">$(PackageDependsOn);BuildMetapackage;BuildTemplates;SplitPackages</PackageDependsOn>
     <VerifyDependsOn Condition="'$(TestOnly)' != 'true'">$(VerifyDependsOn);VerifyCoherentVersions</VerifyDependsOn>
+    <GetArtifactInfoDependsOn>$(GetArtifactInfoDependsOn);ResolveRepoInfo</GetArtifactInfoDependsOn>
   </PropertyGroup>
 
   <Target Name="PrepareOutputPaths">

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview1-15638
-commithash:1d3a0c725dc6b8ae6b0e47800fd6b4d8f8b8d545
+version:2.1.0-preview1-15646
+commithash:c390edb6f73e3ab992402835c004414c1fadfd4a


### PR DESCRIPTION
Output of sharedfx build now matches expected blob store layout

```
<root>/Runtime/$(PackageVersion)/aspnetcore-runtime-$(PackageVersion)-$(Rid).zip
<root>/Runtime/$(PackageVersion)/aspnetcore-runtime-$(Rid)-version-badge.svg
<root>/Runtime/$(PackageVersion)/latest.aspnetcore.version
```


Other changes
- Upgrade build tools
- Produce an SVG badge for the sharedfx
- Produce the 'latest.aspnetcore.version' file for the dotnet-install.ps1/sh downloader script
- Change layout of output for sharefx build
- Use KoreBuild's bundled package folder for internal build tools packages

cc @javiercn 

cc @jkotalik - includes https://github.com/aspnet/BuildTools/commit/c390edb6f73e3ab992402835c004414c1fadfd4a