### PR TITLE
Use platform assemblies paths instead of app paths for crossgen

### DIFF
--- a/build/SharedFx.props
+++ b/build/SharedFx.props
@@ -14,6 +14,9 @@
     <_InstallerSourceDir>$(RepositoryRoot).deps\Installers\</_InstallerSourceDir>
     <_DockerRootDir>/opt/code/</_DockerRootDir>
     <_InstallersOutputDir>$(ArtifactsDir)installers\</_InstallersOutputDir>
+    <!-- 3B = semicolon in ASCII -->
+    <PathSeparator Condition="'$(PathSeparator)' == ''">:</PathSeparator>
+    <PathSeparator Condition="$(SharedFxRID.StartsWith('win'))">%3B</PathSeparator>
 
     <!-- installers -->
     <SharedFxInstallerName>aspnetcore-runtime</SharedFxInstallerName>

--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -208,8 +208,7 @@
       <CrossGenArgs Include="-readytorun" />
       <CrossGenArgs Include="-in %(AssembliesToCrossgen.Source)" />
       <CrossGenArgs Include="-out %(AssembliesToCrossgen.Destination)" />
-      <CrossGenArgs Include="-app_paths $(SharedFxPublishDirectory)" />
-      <CrossGenArgs Include="-platform_assemblies_paths $(SharedFxCrossGenToolDirectory)" />
+      <CrossGenArgs Include="-platform_assemblies_paths $(SharedFxPublishDirectory)$(PathSeparator)$(SharedFxCrossGenToolDirectory)" />
       <CrossGenArgs Include="-JITPath %(ClrJitAssembly.FullPath)" />
     </ItemGroup>
 
@@ -233,8 +232,7 @@
     <ItemGroup>
       <CrossGenSymbolsArgs Include="-nologo" />
       <CrossGenSymbolsArgs Include="-readytorun" />
-      <CrossGenSymbolsArgs Include="-app_paths $(SharedFxPublishDirectory)" />
-      <CrossGenSymbolsArgs Include="-platform_assemblies_paths $(SharedFxCrossGenToolDirectory)" />
+      <CrossGenSymbolsArgs Include="-platform_assemblies_paths $(SharedFxPublishDirectory)$(PathSeparator)$(SharedFxCrossGenToolDirectory)" />
       <CrossGenSymbolsArgs Include="-$(CrossGenSymbolsType)" />
       <CrossGenSymbolsArgs Include="%(AssembliesToCrossgen.Symbols)" />
       <CrossGenSymbolsArgs Include="%(AssembliesToCrossgen.Destination)" />


### PR DESCRIPTION
From our email discussions, it seems like we would rather use platform_assemblies_paths instead of app_paths though theoretically they should be equivalent in our use case.