### PR TITLE
Add TFM compatibility check to 2.1 metapackage

### DIFF
--- a/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
+++ b/src/Microsoft.AspNetCore.All/Microsoft.AspNetCore.All.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <Content Include="build\$(TargetFramework)\*.props" PackagePath="%(Identity)" />
+    <Content Include="build\$(TargetFramework)\*.targets" PackagePath="%(Identity)" />
     <Content Include="lib\$(TargetFramework)\_._" PackagePath="%(Identity)" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.All/build/netcoreapp2.1/Microsoft.AspNetCore.All.targets
+++ b/src/Microsoft.AspNetCore.All/build/netcoreapp2.1/Microsoft.AspNetCore.All.targets
@@ -1,0 +1,7 @@
+<Project InitialTargets="EnsureTFMCompatibility">
+  <Target Name="EnsureTFMCompatibility">
+    <Error
+      Text="This version of Microsoft.AspNetCore.All is only compatible with the netcoreapp2.1 target framework."
+      Condition="'$(TargetFramework)' != 'netcoreapp2.1'"/>
+  </Target>
+</Project>


### PR DESCRIPTION
Last work item in https://github.com/aspnet/Universe/issues/662.

I'm wondering if we should backport this to the 2.0 metapackage and make it only compatible with netcoreapp2.0. 

I'm adding an initial target that should be run before build or publish. Is there a better approach?