### PR TITLE
Update rhel.7 image used to build rpms

### DIFF
--- a/build/tools/docker/rhel.7/Dockerfile
+++ b/build/tools/docker/rhel.7/Dockerfile
@@ -4,11 +4,7 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM microsoft/dotnet-buildtools-prereqs:rhel-7-rpmpkg-c982313-20174116044113
-
-# Install from sudo main package TODO This package needs to be mirrored
-RUN yum install -y https://www.sudo.ws/sudo/dist/packages/RHEL/7/sudo-1.8.20-3.el7.x86_64.rpm \
-    && yum clean all
+FROM microsoft/dotnet-buildtools-prereqs:rhel-7-rpmpkg-e1b4a89-20175311035359
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0


### PR DESCRIPTION
We need this to fix our shared fx installer builds. Changes are the same as dotnet/cli#8151.

fyi @muratg @Eilon since it's ask mode, note this is only affecting build infrastructure.