### PR TITLE
Ensure all packages are included in ArtifactInfo

### DIFF
--- a/build/Publish.targets
+++ b/build/Publish.targets
@@ -55,7 +55,7 @@
       Value="$(PackageVersion)" />
   </Target>
 
-  <Target Name="GetFilesToPublish" DependsOnTargets="ResolveRepoInfo;GeneratePublishFiles">
+  <Target Name="GetFilesToPublish" DependsOnTargets="GetArtifactInfo;GeneratePublishFiles">
     <PropertyGroup>
       <BlobBasePath>Runtime/$(PackageVersion)/</BlobBasePath>
       <AliasBlobBasePath>Runtime/$(SharedFxCliBlobChannel)/</AliasBlobBasePath>
@@ -133,7 +133,12 @@
       <Output TaskParameter="JoinResult" ItemName="PackagesToPublish" />
     </RepoTasks.JoinItems>
 
-    <Message Text="@(FilesToPublish -> '%(FullPath) -> %(RelativeBlobPath)','%0A')" />
+    <ItemGroup>
+      <_MissingPackages Include="@(PackageArtifact)" />
+      <_MissingPackages Remove="%(PackagesToPublish.PackageId)" />
+    </ItemGroup>
+
+    <Error Text="Missing expected packages from PackagesToPublish: %0A - @(_MissingPackages, '%0A - ')" Condition="@(_MissingPackages->Count()) != 0" />
   </Target>
 
   <Target Name="_CheckFilesToPublish">

--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -3,8 +3,26 @@
   <Import Project="SharedFx.props" />
 
   <PropertyGroup>
+    <GetArtifactInfoDependsOn>$(GetArtifactInfoDependsOn);GetMetapackageArtifactInfo</GetArtifactInfoDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <SharedFxOutputPath>$([MSBuild]::NormalizeDirectory($(ArtifactsDir)))assets\Runtime\$(PackageVersion)\</SharedFxOutputPath>
   </PropertyGroup>
+
+  <Target Name="GetMetapackageArtifactInfo">
+    <ItemGroup>
+      <_MetapackageProject Include="$(RepositoryRoot)src\Microsoft.AspNetCore.All\Microsoft.AspNetCore.All.csproj" />
+      <_MetapackageProject Include="$(RepositoryRoot)src\Microsoft.AspNetCore.App\Microsoft.AspNetCore.App.csproj" />
+      <_MetapackageProject Include="$(RepositoryRoot)src\Microsoft.AspNetCore.Analyzers\Microsoft.AspNetCore.Analyzers.csproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(_MetapackageProject)"
+      Targets="GetArtifactInfo"
+      Properties="PackageOutputPath=$(BuildDir);BuildNumber=$(BuildNumber);DesignTimeBuild=true;IsFinalBuild=$(IsFinalBuild)">
+      <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
+    </MSBuild>
+  </Target>
 
   <Target Name="_BuildMetapackage" DependsOnTargets="ResolveRepoInfo">
     <PropertyGroup>

--- a/build/Templating.targets
+++ b/build/Templating.targets
@@ -1,24 +1,40 @@
 <Project>
   <PropertyGroup>
     <TemplatingProjectRoot>$(MSBuildThisFileDirectory)..\modules\Templating\</TemplatingProjectRoot>
+    <GetArtifactInfoDependsOn>$(GetArtifactInfoDependsOn);GetTemplateArtifactInfo</GetArtifactInfoDependsOn>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <TemplateProjProperties>
+      RepositoryRoot=$(TemplatingProjectRoot);
+      BuildNumber=$(BuildNumber);
+      Configuration=$(Configuration);
+      IsFinalBuild=$(IsFinalBuild);
+    </TemplateProjProperties>
+  </PropertyGroup>
+
+  <Target Name="GetTemplateArtifactInfo">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+      Targets="GetArtifactInfo"
+      Properties="$(TemplateProjProperties);DesignTimeBuild=true">
+      <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
+    </MSBuild>
+  </Target>
 
   <Target Name="BuildTemplates" DependsOnTargets="GeneratePropsFiles">
     <PropertyGroup>
-      <TemplateProjProperties>
-        RepositoryRoot=$(TemplatingProjectRoot);
+      <_BuildTemplateProjProperties>
+        $(TemplateProjProperties);
+        SkipAspNetCoreRuntimeInstall=true;
         DotNetRestoreSourcesPropsPath=$(GeneratedRestoreSourcesPropsPath);
         DotNetPackageVersionPropsPath=$(GeneratedPackageVersionPropsPath);
-        BuildNumber=$(BuildNumber);
-        Configuration=$(Configuration);
-        IsFinalBuild=$(IsFinalBuild);
-        SkipAspNetCoreRuntimeInstall=true;
-      </TemplateProjProperties>
+        SkipTests=true;
+      </_BuildTemplateProjProperties>
     </PropertyGroup>
 
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="CleanArtifacts;Build"
-             Properties="$(TemplateProjProperties);SkipTests=true" />
+             Properties="$(_BuildTemplateProjProperties)" />
 
     <ItemGroup>
       <TemplateArtifacts Include="$(TemplatingProjectRoot)artifacts\build\*" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,11 @@
+<Project>
+  <Target Name="GetArtifactInfo" Returns="@(ArtifactInfo)">
+    <ItemGroup>
+      <ArtifactInfo Include="$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg">
+        <ArtifactType>NuGetPackage</ArtifactType>
+        <PackageId>$(PackageId)</PackageId>
+        <Version>$(PackageVersion)</Version>
+      </ArtifactInfo>
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
`/t:GetFilesToPublish` is missing packages to publish that don't come from the standard repo build.

Adds
  - ArtifactInfo items for metapackages and templates packages
  - a build error if there isn't a one to one mapping of ArtifactInfo to PackageArtifact items