### PR TITLE
Include SpaServices.Extensions in .App and .All metapackages

### DIFF
--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -168,7 +168,7 @@
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client.MsgPack" Category="ship" />
 
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
-    <PackageArtifact Include="Microsoft.AspNetCore.SpaServices.Extensions" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.SpaServices.Extensions" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.SpaTemplates" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.StaticFiles" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.TestHost" Category="ship" />


### PR DESCRIPTION
This should fix the VSTS issue 555879 where SpaServices.Extensions is missing from the offline scenarios.