### PR TITLE
Include Microsoft.AspNetCore.App in the LZMA

### DIFF
--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -29,7 +29,7 @@
     <PackageArtifact Include="dotnet-watch" Category="ship" LZMA="true" PackageType="DotnetTool" />
     <PackageArtifact Include="Microsoft.AspNet.Identity.AspNetCoreCompat" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
-    <PackageArtifact Include="Microsoft.AspNetCore.App" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.App" Category="ship" LZMA="true" />
     <PackageArtifact Include="Microsoft.AspNetCore.All" Category="ship" LZMA="true" />
     <PackageArtifact Include="Microsoft.AspNetCore.Analyzers" Category="shipoob" />
     <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Category="ship" AppMetapackage="true" AllMetapackage="true"/>


### PR DESCRIPTION
Forgot to include the .App metapackage to the LZMA after removing it as a dependency of .All in https://github.com/aspnet/Universe/pull/837. This broke offline scenarios where templates are now using .App as the default metapackage.

cc @DamianEdwards @Eilon as this is required for preview1.