### PR TITLE
[2.1-preview1] Publish corefxlab packages to the transport feed

### DIFF
--- a/build/Publish.targets
+++ b/build/Publish.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <DependencyAssetsDir>$(RepositoryRoot).deps\assets\</DependencyAssetsDir>
     <DependencyPackagesDir>$(RepositoryRoot).deps\packages\</DependencyPackagesDir>
+    <DependencyMirrorDir>$(RepositoryRoot).deps\mirror\</DependencyMirrorDir>
     <DependencySymbolsDir>$(RepositoryRoot).deps\symbols\</DependencySymbolsDir>
     <!-- This file is used by the dotnet/cli to determine if our shared framework aligns with the version they pull. -->
     <BaseRuntimeVersionFileName>aspnetcore_base_runtime.version</BaseRuntimeVersionFileName>
@@ -117,6 +118,7 @@
         <Overwrite>true</Overwrite>
       </FilesToPublish>
 
+      <!-- Packages -->
       <_Artifact
         Include="@(ArtifactInfo)"
         ArtifactPath="$(DependencyPackagesDir)%(ArtifactInfo.PackageId).%(ArtifactInfo.Version).nupkg"
@@ -135,6 +137,13 @@
     </ItemGroup>
 
     <Error Text="Missing expected packages from PackagesToPublish: %0A - @(_MissingPackages, '%0A - ')" Condition="@(_MissingPackages->Count()) != 0" />
+
+    <!-- Packages from corefxlab: special case - we are shipping these in preview1 from aspnet because the pipelines API won't be in dotnet/corefx until 2.1.0-preview2. -->
+    <ItemGroup>
+      <PackagesToPublish Include="@(ExternalDependency)" Condition="'%(ExternalDependency.Publish)' == 'true'">
+        <ArtifactPath>$(DependencyMirrorDir)%(ExternalDependency.Identity).%(ExternalDependency.Version).nupkg</ArtifactPath>
+      </PackagesToPublish>
+    </ItemGroup>
   </Target>
 
   <Target Name="_CheckFilesToPublish">

--- a/build/external-dependencies.props
+++ b/build/external-dependencies.props
@@ -117,11 +117,13 @@
     <CoreFxLabFeed>https://dotnet.myget.org/f/dotnet-corefxlab/api/v3/index.json</CoreFxLabFeed>
   </PropertyGroup>
   <ItemGroup>
-    <ExternalDependency Include="System.Buffers.Primitives" Version="$(SystemBuffersPrimitivesPackageVersion)" Source="$(CoreFxLabFeed)" Private="true" Mirror="true" />
-    <ExternalDependency Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" Source="$(CoreFxLabFeed)" Mirror="true" />
+    <!-- For tests only: -->
     <ExternalDependency Include="System.IO.Pipelines.Testing" Version="$(SystemIOPipelinesTestingPackageVersion)" Source="$(CoreFxLabFeed)" Mirror="true" />
-    <ExternalDependency Include="System.Text.Encodings.Web.Utf8" Version="$(SystemTextEncodingsWebUtf8PackageVersion)" Source="$(CoreFxLabFeed)" Mirror="true" />
-    <ExternalDependency Include="System.Text.Primitives" Version="$(SystemTextPrimitivesPackageVersion)" Source="$(CoreFxLabFeed)" Private="true" Mirror="true" />
+    <!-- Published for preview1: -->
+    <ExternalDependency Include="System.Buffers.Primitives" Version="$(SystemBuffersPrimitivesPackageVersion)" Source="$(CoreFxLabFeed)" Private="true" Mirror="true" Publish="true" />
+    <ExternalDependency Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" Source="$(CoreFxLabFeed)" Mirror="true" Publish="true" />
+    <ExternalDependency Include="System.Text.Encodings.Web.Utf8" Version="$(SystemTextEncodingsWebUtf8PackageVersion)" Source="$(CoreFxLabFeed)" Mirror="true" Publish="true" />
+    <ExternalDependency Include="System.Text.Primitives" Version="$(SystemTextPrimitivesPackageVersion)" Source="$(CoreFxLabFeed)" Private="true" Mirror="true" Publish="true" />
   </ItemGroup>
   <!-- Roslyn -->
   <PropertyGroup>


### PR DESCRIPTION
Resolves https://github.com/aspnet/Universe/issues/892

This will push the following packages from corefxlab into prodcon output, and eventually, to nuget.org.

 - System.Buffers.Primitives
 -  System.IO.Pipelines
 - System.Text.Encodings.Web.Utf8
 - System.Text.Primitives

For preview1 only! This should be reverted for preview2 as these packages should be coming from dotnet/corefx. Using #893 to ensure this is reverted.

cc @muratg @ahsonkhan @pakrym @dagood @mmitche @joshfree 