### PR TITLE
Remove MsgPack from .All metapackage

### DIFF
--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -158,16 +158,16 @@
     <PackageArtifact Include="Microsoft.AspNetCore.Sockets.Common.Http" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Sockets.Http" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
 
-    <!-- SignalR Redis and MsgPack Protocol support are not part of the .App meta-package -->
+    <!-- SignalR Redis support is not part of the .App meta-package -->
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Redis" Category="ship" AllMetapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Protocols.MsgPack" Category="ship" AllMetapackage="true" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.MsgPack" Category="ship" AllMetapackage="true" />
 
-    <!-- SignalR Client support are not part of any meta-packages -->
+    <!-- SignalR Client and MsgPack Protocol support are not part of any meta-packages -->
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client.Core" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Sockets.Client.Http" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client.MsgPack" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Protocols.MsgPack" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.MsgPack" Category="ship" />
 
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices.Extensions" Category="ship" AppMetapackage="true" AllMetapackage="true"/>


### PR DESCRIPTION
Spoke to @anurse online and he believes msgpack support should not be in the .All metapackage.

FYI @DamianEdwards 