### PR TITLE
Remove duplicate files from symbols packages

### DIFF
--- a/build/tools/templates/SharedFxSymbols/SharedFrameworkSymbols.nuspec
+++ b/build/tools/templates/SharedFxSymbols/SharedFrameworkSymbols.nuspec
@@ -14,9 +14,5 @@
     <serviceable Condition="'$(Configuration)' == 'Release'">true</serviceable>
     <tags>aspnetcore</tags>
   </metadata>
-  <files>
-    <file src="**\*.dll" target="" />
-    <file src="**\*.map" target="" />
-    <file src="**\*.pdb" target="" />
-  </files>
+  <files />
 </package>


### PR DESCRIPTION
When we used the updated cli, the behaviour of globbing inside nuspec files changed. Currently we include the symbols files twice, once by globbing in MSBuild and once by globbing in the nuspec. The globbing in MSBuild is consistent and will return 
```
Packing C:\gh\Universe\.w\Symbols\Microsoft.AspNetCore.All\runtimes\win-x64\lib\netcoreapp2.1\Microsoft.Azure.KeyVault.dll => runtimes\win-x64\lib\netcoreapp2.1\Microsoft.Azure.KeyVault.dll
```
This was the same path produced by globbing in the nuspec which is why our builds previously only included the files once in the final symbols nupkg.

However, in the updated CLI, the globbing pattern in the nuspec started to return results like:
```
Packing C:\gh\Universe\.w\Symbols\Microsoft.AspNetCore.All\\runtimes\win-x64\lib\netcoreapp2.1\Microsoft.Azure.KeyVault.dll => runtimes\win-x64\lib\netcoreapp2.1\Microsoft.Azure.KeyVault.dll
```
The double `\\` was enough to mark these as separate files which caused the duplicate files in the resultant symbols files.

Regardless, we should never have included the symbols files twice in both the nuspec and in our MSBuild targets. I have verified that this change fixes the problem locally.