### PR TITLE
Include symbols in published output

### DIFF
--- a/build/Publish.targets
+++ b/build/Publish.targets
@@ -59,6 +59,7 @@
   <Target Name="GetFilesToPublish" DependsOnTargets="GetArtifactInfo;GeneratePublishFiles">
     <PropertyGroup>
       <BlobBasePath>aspnetcore/Runtime/$(PackageVersion)/</BlobBasePath>
+      <NpmBlobBasePath>aspnetcore/npm/</NpmBlobBasePath>
       <AliasBlobBasePath>aspnetcore/Runtime/$(SharedFxCliBlobChannel)/</AliasBlobBasePath>
       <PackageArchiveFileName>nuGetPackagesArchive-$(PackageVersion).lzma</PackageArchiveFileName>
       <InstallerBaseFileName>aspnetcore-runtime-$(PackageVersion)</InstallerBaseFileName>
@@ -133,7 +134,11 @@
         ArtifactPath="$(DependencyPackagesDir)%(ArtifactInfo.PackageId).%(ArtifactInfo.Version).symbols.nupkg"
         Condition="'%(ArtifactInfo.ArtifactType)' == 'NuGetSymbolsPackage'" />
 
-      <NpmPackageToPublish Include="$(DependencyAssetsDir)%(ArtifactInfo.FileName)%(ArtifactInfo.Extension)" Condition="'%(ArtifactInfo.ArtifactType)' == 'NpmPackage'" />
+      <NpmPackageToPublish Include="$(DependencyAssetsDir)%(ArtifactInfo.FileName)%(ArtifactInfo.Extension)" Condition="'%(ArtifactInfo.ArtifactType)' == 'NpmPackage'">
+        <RelativeBlobPath>$(NpmBlobBasePath)%(ArtifactInfo.PackageId)/%(ArtifactInfo.FileName)%(ArtifactInfo.Extension)</RelativeBlobPath>
+        <ManifestArtifactData>Type=NpmPackage</ManifestArtifactData>
+        <ContentType>application/tar+gzip</ContentType>
+      </NpmPackageToPublish>
     </ItemGroup>
 
     <!-- Join required because shipping category is stored in universe (PackageArtifact), but information about package ID and version comes from repos (ArtifactInfo). -->
@@ -246,6 +251,10 @@
         Include="@(PackageToPublish)"
         ManifestArtifactData="NonShipping=true"
         Condition="'%(PackageToPublish.Category)' != 'ship'" />
+
+      <FilesToPublishToTransport Include="@(NpmPackageToPublish)"
+        RelativeBlobPath="$(BlobFileRelativePathBase)%(NpmPackageToPublish.RelativeBlobPath)"
+        ManifestArtifactData="%(NpmPackageToPublish.ManifestArtifactData)" />
 
       <!-- Filter aliased artifacts to workaround dotnet/buildtools#1855 -->
       <FilesToPublishToTransport Include="@(FilesToPublish)"

--- a/build/Publish.targets
+++ b/build/Publish.targets
@@ -138,33 +138,24 @@
 
     <!-- Join required because shipping category is stored in universe (PackageArtifact), but information about package ID and version comes from repos (ArtifactInfo). -->
     <RepoTasks.JoinItems
-      Left="@(_PackageArtifactInfo)" LeftKey="PackageId" LeftMetadata="*" LeftItemSpec="Identity"
+      Left="@(_PackageArtifactInfo->WithMetadataValue('Category',''))" LeftKey="PackageId" LeftMetadata="*" LeftItemSpec="Identity"
       Right="@(PackageArtifact)" RightMetadata="Category">
       <Output TaskParameter="JoinResult" ItemName="_PackageArtifactInfoWithCategory" />
     </RepoTasks.JoinItems>
 
-    <ItemGroup>
-      <_MissingPackageArtifact Include="@(PackageArtifact)" />
-      <_MissingPackageArtifact Remove="%(_PackageArtifactInfoWithCategory.PackageId)" />
-    </ItemGroup>
-
     <RepoTasks.JoinItems
-      Left="@(_SymbolsPackageArtifactInfo)" LeftKey="PackageId" LeftMetadata="*" LeftItemSpec="Identity"
+      Left="@(_SymbolsPackageArtifactInfo->WithMetadataValue('Category',''))" LeftKey="PackageId" LeftMetadata="*" LeftItemSpec="Identity"
       Right="@(PackageArtifact)" RightMetadata="Category">
       <Output TaskParameter="JoinResult" ItemName="_SymbolsArtifactInfoWithCategory" />
     </RepoTasks.JoinItems>
 
-    <!--
-      Add symbols packages to PackageToPublish after validating PackageToPublish matches PackageArtifact.
-      We don't always produce a symbols package for each regular packages.
-    -->
     <ItemGroup>
       <PackageToPublish Include="%(_PackageArtifactInfoWithCategory.ArtifactPath)" Category="%(_PackageArtifactInfoWithCategory.Category)" />
+      <PackageToPublish Include="%(_PackageArtifactInfo.ArtifactPath)" Category="%(_PackageArtifactInfo.Category)" Condition="'%(_PackageArtifactInfo.Category)' != ''" />
       <PackageToPublish Include="%(_SymbolsArtifactInfoWithCategory.ArtifactPath)" Category="%(_SymbolsArtifactInfoWithCategory.Category)" />
+      <PackageToPublish Include="%(_SymbolsPackageArtifactInfo.ArtifactPath)" Category="%(_SymbolsPackageArtifactInfo.Category)" Condition="'%(_SymbolsPackageArtifactInfo.Category)' != ''" />
     </ItemGroup>
-  </Target>
 
-  <Target Name="_CheckFilesToPublish">
     <ItemGroup>
       <_MissingArtifactFile Include="@(FilesToPublish)" Condition="!Exists(%(FilesToPublish.Identity))" />
       <_MissingArtifactFile Include="@(NpmPackageToPublish)" Condition="!Exists(%(NpmPackageToPublish.Identity))" />
@@ -172,15 +163,14 @@
     </ItemGroup>
 
     <Error Text="Missing expected files:%0A - @(_MissingArtifactFile, '%0A - ')" Condition="@(_MissingArtifactFile->Count()) != 0" />
-    <Error Text="Missing expected packages from PackageToPublish. These were defined as expected PackageArtifact's in artifacts.props: %0A - @(_MissingPackageArtifact, '%0A - ')" Condition="@(_MissingPackageArtifact->Count()) != 0" />
   </Target>
 
-  <Target Name="CopyToPublishArtifacts" DependsOnTargets="_CheckFilesToPublish">
+  <Target Name="CopyToPublishArtifacts" DependsOnTargets="GetFilesToPublish">
     <Copy SourceFiles="%(FilesToPublish.Identity)" DestinationFiles="$(ArtifactsDir)%(FilesToPublish.RelativeBlobPath)" Condition="'%(FilesToPublish.RelativeBlobPath)' != ''" />
   </Target>
 
   <Target Name="PublishToMyGet"
-          DependsOnTargets="_CheckFilesToPublish;GetToolsets"
+          DependsOnTargets="GetFilesToPublish;GetToolsets"
           Condition="'$(PublishToMyget)' == 'true'">
 
     <Error Text="Missing required property: PublishMyGetFeedUrl"  Condition=" '$(PublishMyGetFeedUrl)' == '' "/>
@@ -221,7 +211,7 @@
   </Target>
 
   <Target Name="PublishToAzureFeed"
-    DependsOnTargets="_CheckFilesToPublish"
+    DependsOnTargets="GetFilesToPublish"
     Condition="'$(PublishToAzureFeed)' == 'true'">
 
     <PropertyGroup>
@@ -244,7 +234,7 @@
   </Target>
 
   <Target Name="PublishToTransportFeed"
-    DependsOnTargets="ResolveCommitHash;GetFilesToPublish;_CheckFilesToPublish"
+    DependsOnTargets="ResolveCommitHash;GetFilesToPublish"
     Condition="'$(PublishToTransportFeed)' == 'true'">
 
     <ItemGroup>

--- a/build/SharedFx.props
+++ b/build/SharedFx.props
@@ -56,7 +56,8 @@
 
   <ItemGroup>
     <WindowsSharedFxRIDs Include="win-x64;win-x86"/>
-    <NonWindowsSharedFxRIDs Include="osx-x64;linux-x64" />
+    <NonWindowsSharedFxRIDs Include="osx-x64" CrossgenSymbolsSupported="false" />
+    <NonWindowsSharedFxRIDs Include="linux-x64" />
     <NonWindowsSharedFxRIDs Include="alpine.3.6-x64" />
     <AllSharedFxRIDs Include="@(WindowsSharedFxRIDs);@(NonWindowsSharedFxRIDs)"/>
   </ItemGroup>

--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -25,7 +25,7 @@
 
     <ItemGroup>
       <!-- Cartesian products in MSBuild are fun :) -->
-      <_SharedFrameworkSymbolsPackage Include="@(SharedFrameworkName)">
+      <_SharedFrameworkSymbolsPackage Include="@(SharedFrameworkName)" Condition="'%(AllSharedFxRIDs.CrossgenSymbolsSupported)' != 'false'">
         <Rid>%(AllSharedFxRIDs.Identity)</Rid>
       </_SharedFrameworkSymbolsPackage>
       <_SharedFrameworkSymbolsPackage Update="@(_SharedFrameworkSymbolsPackage)" PackageId="runtime.%(Rid).%(Identity)" />

--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -22,6 +22,20 @@
       Properties="PackageOutputPath=$(BuildDir);BuildNumber=$(BuildNumber);DesignTimeBuild=true;IsFinalBuild=$(IsFinalBuild)">
       <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
     </MSBuild>
+
+    <ItemGroup>
+      <!-- Cartesian products in MSBuild are fun :) -->
+      <_SharedFrameworkSymbolsPackage Include="@(SharedFrameworkName)">
+        <Rid>%(AllSharedFxRIDs.Identity)</Rid>
+      </_SharedFrameworkSymbolsPackage>
+      <_SharedFrameworkSymbolsPackage Update="@(_SharedFrameworkSymbolsPackage)" PackageId="runtime.%(Rid).%(Identity)" />
+      <ArtifactInfo Include="@(_SharedFrameworkSymbolsPackage->'$(BuildDir)%(PackageId).$(PackageVersion).symbols.nupkg')">
+        <ArtifactType>NuGetSymbolsPackage</ArtifactType>
+        <PackageId>%(_SharedFrameworkSymbolsPackage.PackageId)</PackageId>
+        <Version>$(PackageVersion)</Version>
+        <Category>shipoob</Category>
+      </ArtifactInfo>
+    </ItemGroup>
   </Target>
 
   <Target Name="_BuildMetapackage" DependsOnTargets="ResolveRepoInfo">

--- a/build/repo.props
+++ b/build/repo.props
@@ -34,6 +34,9 @@
     <NativeInstaller Include="x64" FileExt=".deb" />
     <NativeInstaller Include="x64" FileExt=".rpm" />
     <NativeInstaller Include="rh.rhel.7-x64" FileExt=".rpm" />
+
+    <SharedFrameworkName Include="Microsoft.AspNetCore.All" />
+    <SharedFrameworkName Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Latest ProdCon build was not publishing symbols for the sharedfx or packages.

Changes:
 - update build tools to ensure symbols packages from repos are included
 - add package info for sharedfx symbols nupkgs

Here is a complete list of all files expected to exist during publishing. 

https://gist.github.com/natemcmaster/5ae280dd41efe44efa7b603fb4198433