### PR TITLE
Merge release/2.1 into dev

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+[submodule "modules/AADIntegration"]
+	path = modules/AADIntegration
+	url = https://github.com/aspnet/AADIntegration.git
+	branch = dev
 [submodule "modules/Antiforgery"]
 	path = modules/Antiforgery
 	url = https://github.com/aspnet/Antiforgery.git

--- a/build/Publish.targets
+++ b/build/Publish.targets
@@ -59,6 +59,7 @@
   <Target Name="GetFilesToPublish" DependsOnTargets="GetArtifactInfo;GeneratePublishFiles">
     <PropertyGroup>
       <BlobBasePath>aspnetcore/Runtime/$(PackageVersion)/</BlobBasePath>
+      <NpmBlobBasePath>aspnetcore/npm/</NpmBlobBasePath>
       <AliasBlobBasePath>aspnetcore/Runtime/$(SharedFxCliBlobChannel)/</AliasBlobBasePath>
       <PackageArchiveFileName>nuGetPackagesArchive-$(PackageVersion).lzma</PackageArchiveFileName>
       <InstallerBaseFileName>aspnetcore-runtime-$(PackageVersion)</InstallerBaseFileName>
@@ -133,38 +134,33 @@
         ArtifactPath="$(DependencyPackagesDir)%(ArtifactInfo.PackageId).%(ArtifactInfo.Version).symbols.nupkg"
         Condition="'%(ArtifactInfo.ArtifactType)' == 'NuGetSymbolsPackage'" />
 
-      <NpmPackageToPublish Include="$(DependencyAssetsDir)%(ArtifactInfo.FileName)%(ArtifactInfo.Extension)" Condition="'%(ArtifactInfo.ArtifactType)' == 'NpmPackage'" />
+      <NpmPackageToPublish Include="$(DependencyAssetsDir)%(ArtifactInfo.FileName)%(ArtifactInfo.Extension)" Condition="'%(ArtifactInfo.ArtifactType)' == 'NpmPackage'">
+        <RelativeBlobPath>$(NpmBlobBasePath)%(ArtifactInfo.PackageId)/%(ArtifactInfo.FileName)%(ArtifactInfo.Extension)</RelativeBlobPath>
+        <ManifestArtifactData>Type=NpmPackage</ManifestArtifactData>
+        <ContentType>application/tar+gzip</ContentType>
+      </NpmPackageToPublish>
     </ItemGroup>
 
     <!-- Join required because shipping category is stored in universe (PackageArtifact), but information about package ID and version comes from repos (ArtifactInfo). -->
     <RepoTasks.JoinItems
-      Left="@(_PackageArtifactInfo)" LeftKey="PackageId" LeftMetadata="*" LeftItemSpec="Identity"
+      Left="@(_PackageArtifactInfo->WithMetadataValue('Category',''))" LeftKey="PackageId" LeftMetadata="*" LeftItemSpec="Identity"
       Right="@(PackageArtifact)" RightMetadata="Category">
       <Output TaskParameter="JoinResult" ItemName="_PackageArtifactInfoWithCategory" />
     </RepoTasks.JoinItems>
 
-    <ItemGroup>
-      <_MissingPackageArtifact Include="@(PackageArtifact)" />
-      <_MissingPackageArtifact Remove="%(_PackageArtifactInfoWithCategory.PackageId)" />
-    </ItemGroup>
-
     <RepoTasks.JoinItems
-      Left="@(_SymbolsPackageArtifactInfo)" LeftKey="PackageId" LeftMetadata="*" LeftItemSpec="Identity"
+      Left="@(_SymbolsPackageArtifactInfo->WithMetadataValue('Category',''))" LeftKey="PackageId" LeftMetadata="*" LeftItemSpec="Identity"
       Right="@(PackageArtifact)" RightMetadata="Category">
       <Output TaskParameter="JoinResult" ItemName="_SymbolsArtifactInfoWithCategory" />
     </RepoTasks.JoinItems>
 
-    <!--
-      Add symbols packages to PackageToPublish after validating PackageToPublish matches PackageArtifact.
-      We don't always produce a symbols package for each regular packages.
-    -->
     <ItemGroup>
       <PackageToPublish Include="%(_PackageArtifactInfoWithCategory.ArtifactPath)" Category="%(_PackageArtifactInfoWithCategory.Category)" />
+      <PackageToPublish Include="%(_PackageArtifactInfo.ArtifactPath)" Category="%(_PackageArtifactInfo.Category)" Condition="'%(_PackageArtifactInfo.Category)' != ''" />
       <PackageToPublish Include="%(_SymbolsArtifactInfoWithCategory.ArtifactPath)" Category="%(_SymbolsArtifactInfoWithCategory.Category)" />
+      <PackageToPublish Include="%(_SymbolsPackageArtifactInfo.ArtifactPath)" Category="%(_SymbolsPackageArtifactInfo.Category)" Condition="'%(_SymbolsPackageArtifactInfo.Category)' != ''" />
     </ItemGroup>
-  </Target>
 
-  <Target Name="_CheckFilesToPublish">
     <ItemGroup>
       <_MissingArtifactFile Include="@(FilesToPublish)" Condition="!Exists(%(FilesToPublish.Identity))" />
       <_MissingArtifactFile Include="@(NpmPackageToPublish)" Condition="!Exists(%(NpmPackageToPublish.Identity))" />
@@ -172,15 +168,14 @@
     </ItemGroup>
 
     <Error Text="Missing expected files:%0A - @(_MissingArtifactFile, '%0A - ')" Condition="@(_MissingArtifactFile->Count()) != 0" />
-    <Error Text="Missing expected packages from PackageToPublish. These were defined as expected PackageArtifact's in artifacts.props: %0A - @(_MissingPackageArtifact, '%0A - ')" Condition="@(_MissingPackageArtifact->Count()) != 0" />
   </Target>
 
-  <Target Name="CopyToPublishArtifacts" DependsOnTargets="_CheckFilesToPublish">
+  <Target Name="CopyToPublishArtifacts" DependsOnTargets="GetFilesToPublish">
     <Copy SourceFiles="%(FilesToPublish.Identity)" DestinationFiles="$(ArtifactsDir)%(FilesToPublish.RelativeBlobPath)" Condition="'%(FilesToPublish.RelativeBlobPath)' != ''" />
   </Target>
 
   <Target Name="PublishToMyGet"
-          DependsOnTargets="_CheckFilesToPublish;GetToolsets"
+          DependsOnTargets="GetFilesToPublish;GetToolsets"
           Condition="'$(PublishToMyget)' == 'true'">
 
     <Error Text="Missing required property: PublishMyGetFeedUrl"  Condition=" '$(PublishMyGetFeedUrl)' == '' "/>
@@ -221,7 +216,7 @@
   </Target>
 
   <Target Name="PublishToAzureFeed"
-    DependsOnTargets="_CheckFilesToPublish"
+    DependsOnTargets="GetFilesToPublish"
     Condition="'$(PublishToAzureFeed)' == 'true'">
 
     <PropertyGroup>
@@ -244,7 +239,7 @@
   </Target>
 
   <Target Name="PublishToTransportFeed"
-    DependsOnTargets="ResolveCommitHash;GetFilesToPublish;_CheckFilesToPublish"
+    DependsOnTargets="ResolveCommitHash;GetFilesToPublish"
     Condition="'$(PublishToTransportFeed)' == 'true'">
 
     <ItemGroup>
@@ -256,6 +251,10 @@
         Include="@(PackageToPublish)"
         ManifestArtifactData="NonShipping=true"
         Condition="'%(PackageToPublish.Category)' != 'ship'" />
+
+      <FilesToPublishToTransport Include="@(NpmPackageToPublish)"
+        RelativeBlobPath="$(BlobFileRelativePathBase)%(NpmPackageToPublish.RelativeBlobPath)"
+        ManifestArtifactData="%(NpmPackageToPublish.ManifestArtifactData)" />
 
       <!-- Filter aliased artifacts to workaround dotnet/buildtools#1855 -->
       <FilesToPublishToTransport Include="@(FilesToPublish)"

--- a/build/SharedFx.props
+++ b/build/SharedFx.props
@@ -56,7 +56,8 @@
 
   <ItemGroup>
     <WindowsSharedFxRIDs Include="win-x64;win-x86"/>
-    <NonWindowsSharedFxRIDs Include="osx-x64;linux-x64" />
+    <NonWindowsSharedFxRIDs Include="osx-x64" CrossgenSymbolsSupported="false" />
+    <NonWindowsSharedFxRIDs Include="linux-x64" />
     <NonWindowsSharedFxRIDs Include="alpine.3.6-x64" />
     <AllSharedFxRIDs Include="@(WindowsSharedFxRIDs);@(NonWindowsSharedFxRIDs)"/>
   </ItemGroup>

--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -22,6 +22,20 @@
       Properties="PackageOutputPath=$(BuildDir);BuildNumber=$(BuildNumber);DesignTimeBuild=true;IsFinalBuild=$(IsFinalBuild)">
       <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
     </MSBuild>
+
+    <ItemGroup>
+      <!-- Cartesian products in MSBuild are fun :) -->
+      <_SharedFrameworkSymbolsPackage Include="@(SharedFrameworkName)" Condition="'%(AllSharedFxRIDs.CrossgenSymbolsSupported)' != 'false'">
+        <Rid>%(AllSharedFxRIDs.Identity)</Rid>
+      </_SharedFrameworkSymbolsPackage>
+      <_SharedFrameworkSymbolsPackage Update="@(_SharedFrameworkSymbolsPackage)" PackageId="runtime.%(Rid).%(Identity)" />
+      <ArtifactInfo Include="@(_SharedFrameworkSymbolsPackage->'$(BuildDir)%(PackageId).$(PackageVersion).symbols.nupkg')">
+        <ArtifactType>NuGetSymbolsPackage</ArtifactType>
+        <PackageId>%(_SharedFrameworkSymbolsPackage.PackageId)</PackageId>
+        <Version>$(PackageVersion)</Version>
+        <Category>shipoob</Category>
+      </ArtifactInfo>
+    </ItemGroup>
   </Target>
 
   <Target Name="_BuildMetapackage" DependsOnTargets="ResolveRepoInfo">

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -36,6 +36,7 @@
     <PackageArtifact Include="Microsoft.AspNetCore.AspNetCoreModule" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Abstractions" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
+    <PackageArtifact Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Category="ship"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Cookies" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Core" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Facebook" Category="ship" AppMetapackage="true" AllMetapackage="true"/>

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -20,7 +20,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageArtifact Include="dotnet-aspnet-codegenerator" Category="shipoob" />
+    <PackageArtifact Include="dotnet-aspnet-codegenerator" Category="ship" />
     <PackageArtifact Include="dotnet-dev-certs" Category="shipoob" />
     <PackageArtifact Include="dotnet-ef" Category="shipoob" />
     <PackageArtifact Include="dotnet-sql-cache" Category="shipoob" />

--- a/build/repo.props
+++ b/build/repo.props
@@ -34,6 +34,9 @@
     <NativeInstaller Include="x64" FileExt=".deb" />
     <NativeInstaller Include="x64" FileExt=".rpm" />
     <NativeInstaller Include="rh.rhel.7-x64" FileExt=".rpm" />
+
+    <SharedFrameworkName Include="Microsoft.AspNetCore.All" />
+    <SharedFrameworkName Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -199,7 +199,7 @@
   </Target>
 
   <Target Name="CheckUniverse"
-    DependsOnTargets="ComputeGraph;VerifyPackageArtifactConfig" />
+    DependsOnTargets="ComputeGraph;VerifyPackageArtifactConfig;VerifyAllReposHaveNuGetPackageVerifier" />
 
   <Target Name="VerifyCoherentVersions" DependsOnTargets="ResolveRepoInfo">
     <ItemGroup>
@@ -210,6 +210,11 @@
     <RepoTasks.VerifyCoherentVersions
       PackageFiles="@(ShippingPackageFiles)"
       ExternalDependencies="@(ExternalDependency);@(ShippedExternalDependency)" />
+  </Target>
+
+  <Target Name="VerifyAllReposHaveNuGetPackageVerifier" DependsOnTargets="_PrepareRepositories">
+    <Error Condition="!Exists('%(Repository.RootPath)NuGetPackageVerifier.json')"
+           Text="Repository %(Repository.Identity) is missing NuGetPackageVerifier.json. Expected file to exist in %(Repository.RootPath)NuGetPackageVerifier.json" />
   </Target>
 
 </Project>

--- a/build/submodules.props
+++ b/build/submodules.props
@@ -6,6 +6,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
+    <Repository Include="AADIntegration" />
     <Repository Include="Antiforgery" />
     <Repository Include="AuthSamples" />
     <Repository Include="AzureIntegration" />

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview3-15745
-commithash:19eea6e602b4269877be358e1153327cb766eb92
+version:2.1.0-preview3-15746
+commithash:bd7208b1b1533dad0fac5440948312ff269f0fb9

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview3-17000
-commithash:a3c0d9aa5e9fa481608b2310295eb7dcf362b7c1
+version:2.1.0-preview3-17001
+commithash:dda68c56abf0d3b911fe6a2315872c446b314585

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview3-15746
-commithash:bd7208b1b1533dad0fac5440948312ff269f0fb9
+version:2.1.0-preview3-17000
+commithash:a3c0d9aa5e9fa481608b2310295eb7dcf362b7c1


### PR DESCRIPTION
Bring changes back into dev from 2.1. This includes the addition of a new submodule, AADIntegration.

@javiercn I will wait until you have the dev branch of AADIntegration ready to go first. I could merge as is, but the update automation would immediately have trouble with this because dev currently is behind release/2.1 in aspnet/AADIntegration