### PR TITLE
Build runtime specific metapackages

### DIFF
--- a/build/SharedFx.targets
+++ b/build/SharedFx.targets
@@ -13,7 +13,9 @@
   <Target Name="GetMetapackageArtifactInfo">
     <ItemGroup>
       <_MetapackageProject Include="$(RepositoryRoot)src\Microsoft.AspNetCore.All\Microsoft.AspNetCore.All.csproj" />
+      <_MetapackageProject Include="$(RepositoryRoot)src\runtime.win.Microsoft.AspNetCore.All\runtime.win.Microsoft.AspNetCore.All.csproj" />
       <_MetapackageProject Include="$(RepositoryRoot)src\Microsoft.AspNetCore.App\Microsoft.AspNetCore.App.csproj" />
+      <_MetapackageProject Include="$(RepositoryRoot)src\runtime.win.Microsoft.AspNetCore.App\runtime.win.Microsoft.AspNetCore.App.csproj" />
       <_MetapackageProject Include="$(RepositoryRoot)src\Microsoft.AspNetCore.Analyzers\Microsoft.AspNetCore.Analyzers.csproj" />
     </ItemGroup>
 
@@ -75,6 +77,13 @@
       PackageArtifacts="@(PackageArtifact)"
       ExternalDependencies="@(ExternalDependency)" />
 
+    <!-- Update runtime.json.in -->
+    <GenerateFileFromTemplate
+      TemplateFile="$(MetapackageWorkDirectory)runtime.json.in"
+      OutputPath="$(MetapackageWorkDirectory)runtime.json"
+      Properties="METAPACKAGE_ID=$(MetapackageName);PACKAGE_VERSION=$(PackageVersion)"
+      Condition="'$(ProcessRuntimeJson)' == 'true'"/>
+
     <!-- Set _Target=Restore so the project will be re-evaluated to include Internal.AspNetCore.Sdk MSBuild properties on the next step. -->
     <MSBuild Projects="$(MetapackageWorkDirectory)$(MetapackageName).csproj" Targets="Restore" Properties="$(CommonProps);_Target=Restore" />
     <!-- Pack -->
@@ -87,6 +96,15 @@
         <AdditionalProperties>
           MetapackageName=Microsoft.AspNetCore.App;
           MetapackageReferenceType=AppMetapackage;
+          LockToExactVersions=true;
+          ProcessRuntimeJson=true
+        </AdditionalProperties>
+      </_MetapackageBuilderProject>
+
+      <_MetapackageBuilderProject Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>
+          MetapackageName=runtime.win.Microsoft.AspNetCore.App;
+          MetapackageReferenceType=WinAppMetapackage;
           LockToExactVersions=true
         </AdditionalProperties>
       </_MetapackageBuilderProject>
@@ -95,6 +113,15 @@
         <AdditionalProperties>
           MetapackageName=Microsoft.AspNetCore.All;
           MetapackageReferenceType=AllMetapackage;
+          LockToExactVersions=false;
+          ProcessRuntimeJson=true
+        </AdditionalProperties>
+      </_MetapackageBuilderProject>
+
+      <_MetapackageBuilderProject Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>
+          MetapackageName=runtime.win.Microsoft.AspNetCore.All;
+          MetapackageReferenceType=WinAllMetapackage;
           LockToExactVersions=false
         </AdditionalProperties>
       </_MetapackageBuilderProject>

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -6,6 +6,10 @@
       <AppMetapackage>false</AppMetapackage>
       <!-- When true, this dependency will be included in the Microsoft.AspNetCore.All metapackage. -->
       <AllMetapackage>false</AllMetapackage>
+      <!-- When true, this dependency will be included in the runtime.win.Microsoft.AspNetCore.App metapackage. -->
+      <WinAppMetapackage>false</WinAppMetapackage>
+      <!-- When true, this dependency will be included in the runtime.win.Microsoft.AspNetCore.All metapackage. -->
+      <WinAllMetapackage>false</WinAllMetapackage>
       <!-- When true, this dependency will be included in the Microsoft.AspNetCore.Analyzers metapackage. -->
       <Analyzer>false</Analyzer>
       <!-- When true, this dependency will be included in the LZMA. -->
@@ -142,7 +146,7 @@
     <PackageArtifact Include="Microsoft.AspNetCore.Routing.Abstractions" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Routing.DecisionTree.Sources" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Server.HttpSys" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
-    <PackageArtifact Include="Microsoft.AspNetCore.Server.IIS" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.Server.IIS" Category="ship" WinAppMetapackage="true" WinAllMetapackage="true" />
     <PackageArtifact Include="Microsoft.AspNetCore.Server.IISIntegration" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.Server.IntegrationTesting" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Server.Kestrel" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
@@ -304,6 +308,8 @@
     <PackageArtifact Include="Microsoft.VisualStudio.Web.CodeGenerators.Mvc" Category="ship" LZMA="true" />
     <PackageArtifact Include="Microsoft.Web.Xdt.Extensions" Category="shipoob" />
     <PackageArtifact Include="RazorPageGenerator" Category="noship" />
+    <PackageArtifact Include="runtime.win.Microsoft.AspNetCore.App" Category="ship" />
+    <PackageArtifact Include="runtime.win.Microsoft.AspNetCore.All" Category="ship" />
 
     <PackageArtifact Include="Internal.AspNetCore.Universe.Lineup" Category="noship" PackageType="Lineup" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.All/runtime.json.in
+++ b/src/Microsoft.AspNetCore.All/runtime.json.in
@@ -1,0 +1,9 @@
+{
+  "runtimes": {
+    "win": {
+      "${METAPACKAGE_ID}": {
+        "runtime.win.${METAPACKAGE_ID}": "${PACKAGE_VERSION}"
+      }
+    }
+  }
+}

--- a/src/Microsoft.AspNetCore.App/Microsoft.AspNetCore.App.csproj
+++ b/src/Microsoft.AspNetCore.App/Microsoft.AspNetCore.App.csproj
@@ -15,6 +15,7 @@
     <Content Include="build\$(TargetFramework)\*.props" PackagePath="%(Identity)" />
     <Content Include="build\$(TargetFramework)\*.targets" PackagePath="%(Identity)" />
     <Content Include="lib\$(TargetFramework)\_._" PackagePath="%(Identity)" />
+    <Content Include="runtime.json" PackagePath="%(Identity)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.App/runtime.json.in
+++ b/src/Microsoft.AspNetCore.App/runtime.json.in
@@ -1,0 +1,9 @@
+{
+  "runtimes": {
+    "win": {
+      "${METAPACKAGE_ID}": {
+        "runtime.win.${METAPACKAGE_ID}": "${PACKAGE_VERSION}"
+      }
+    }
+  }
+}

--- a/src/runtime.win.Microsoft.AspNetCore.All/runtime.win.Microsoft.AspNetCore.All.csproj
+++ b/src/runtime.win.Microsoft.AspNetCore.All/runtime.win.Microsoft.AspNetCore.All.csproj
@@ -7,15 +7,8 @@
     <IncludeSymbols>false</IncludeSymbols>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <PackageTags>aspnetcore</PackageTags>
-    <Description>Microsoft.AspNetCore.All</Description>
+    <Description>runtime.win.Microsoft.AspNetCore.All</Description>
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="build\$(TargetFramework)\*.props" PackagePath="%(Identity)" />
-    <Content Include="build\$(TargetFramework)\*.targets" PackagePath="%(Identity)" />
-    <Content Include="lib\$(TargetFramework)\_._" PackagePath="%(Identity)" />
-    <Content Include="runtime.json" PackagePath="%(Identity)" />
-  </ItemGroup>
 
 </Project>

--- a/src/runtime.win.Microsoft.AspNetCore.App/runtime.win.Microsoft.AspNetCore.App.csproj
+++ b/src/runtime.win.Microsoft.AspNetCore.App/runtime.win.Microsoft.AspNetCore.App.csproj
@@ -7,15 +7,8 @@
     <IncludeSymbols>false</IncludeSymbols>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <PackageTags>aspnetcore</PackageTags>
-    <Description>Microsoft.AspNetCore.All</Description>
+    <Description>runtime.win.Microsoft.AspNetCore.App</Description>
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="build\$(TargetFramework)\*.props" PackagePath="%(Identity)" />
-    <Content Include="build\$(TargetFramework)\*.targets" PackagePath="%(Identity)" />
-    <Content Include="lib\$(TargetFramework)\_._" PackagePath="%(Identity)" />
-    <Content Include="runtime.json" PackagePath="%(Identity)" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#762 Tested the scenarios outlined in the issue, specifically:
- portable restore does not have Microsoft.AspNetCore.Server.IIS in project.assets.json
- RID specific restore (tested win-x64, win-x86) has Microsoft.AspNetCore.Server.IIS in project.assets.json
- Standalone publish with win-x64 has aspnetcorerh.dll in the output
- Standalone publish with linux-x64 does not have aspnetcorerh.dll in the output