### PR TITLE
Generate branding.g.props for use in downstream builds that need to align version information

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -17,8 +17,9 @@
     <IntermediateMirrorPackageDir>$(IntermediateDir)mirror\</IntermediateMirrorPackageDir>
     <!-- For external packages that come from feeds we don't mirror. -->
     <IntermediateExternalPackageDir>$(IntermediateDir)ext\</IntermediateExternalPackageDir>
-    <GeneratedPackageVersionPropsPath>$(IntermediateDir)dependencies.props</GeneratedPackageVersionPropsPath>
-    <GeneratedRestoreSourcePropsPath>$(IntermediateDir)sources.props</GeneratedRestoreSourcePropsPath>
+    <GeneratedPackageVersionPropsPath>$(IntermediateDir)dependencies.g.props</GeneratedPackageVersionPropsPath>
+    <GeneratedRestoreSourcePropsPath>$(IntermediateDir)sources.g.props</GeneratedRestoreSourcePropsPath>
+    <GeneratedBrandingPropsPath>$(IntermediateDir)branding.g.props</GeneratedBrandingPropsPath>
 
     <PrepareDependsOn>$(PrepareDependsOn);VerifyPackageArtifactConfig;PrepareOutputPath</PrepareDependsOn>
     <CleanDependsOn>$(CleanDependsOn);CleanArtifacts;CleanUniverseArtifacts</CleanDependsOn>
@@ -58,11 +59,32 @@
       Packages="@(_LineupPackages)"
       OutputPath="$(GeneratedPackageVersionPropsPath)" />
 
-    <Copy SourceFiles="$(GeneratedPackageVersionPropsPath)" DestinationFolder="$(ArtifactsDir)" />
-
     <RepoTasks.GenerateRestoreSourcesPropsFile
       Sources="@(_LineupSources)"
       OutputPath="$(GeneratedRestoreSourcePropsPath)" />
+
+    <PropertyGroup>
+      <!-- Generate an MSBuild file that can be imported and used by Windows Installer builds to keep our versions consistent. -->
+      <BrandingPropsContent>
+<![CDATA[
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <AspNetCoreMajorVersion>$(AspNetCoreMajorVersion)</AspNetCoreMajorVersion>
+    <AspNetCoreMinorVersion>$(AspNetCoreMinorVersion)</AspNetCoreMinorVersion>
+    <AspNetCorePatchVersion>$(AspNetCorePatchVersion)</AspNetCorePatchVersion>
+    <AspNetCorePrereleaseVersionLabel>$(PrereleaseVersionLabel)</AspNetCorePrereleaseVersionLabel>
+    <AspNetCoreBuildNumber>$(BuildNumber)</AspNetCoreBuildNumber>
+    <AspNetCoreBrandingVersion>$(PackageBrandingVersion)</AspNetCoreBrandingVersion>
+  </PropertyGroup>
+</Project>
+]]>
+      </BrandingPropsContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(GeneratedBrandingPropsPath)" Overwrite="true" Lines="$(BrandingPropsContent)"/>
+
+    <Copy SourceFiles="$(GeneratedPackageVersionPropsPath);$(GeneratedBrandingPropsPath)" DestinationFolder="$(ArtifactsDir)" />
   </Target>
 
   <Target Name="CleanUniverseArtifacts">

--- a/version.props
+++ b/version.props
@@ -1,12 +1,19 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.7</VersionPrefix>
-    <VersionSuffix>rtm</VersionSuffix>
+    <AspNetCoreMajorVersion>2</AspNetCoreMajorVersion>
+    <AspNetCoreMinorVersion>0</AspNetCoreMinorVersion>
+    <AspNetCorePatchVersion>7</AspNetCorePatchVersion>
+    <VersionPrefix>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion)</VersionPrefix>
+    <PrereleaseVersionLabel>rtm</PrereleaseVersionLabel>
+    <VersionSuffix>$(PrereleaseVersionLabel)</VersionSuffix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersionNoTimestamp Condition="'$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersionNoTimestamp>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <PackageVersionNoTimestamp Condition="'$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersionNoTimestamp>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
+
+    <!-- The 'human friendly' version to display in installers. In pre-release builds, this might be "2.0.7 Preview 2" -->
+    <PackageBrandingVersion>$(VersionPrefix)</PackageBrandingVersion>
 
     <!-- Chains in the previous runtime store installer and files. This must be updated with every patch. -->
     <PreviousRuntimeStoreArchiveVersion>2.0.6-10011</PreviousRuntimeStoreArchiveVersion>


### PR DESCRIPTION
Reduce the number of places we have to manually update to keep our installers consistent with the runtime.