### PR TITLE
[2.0.x] Add ANCM version to generate list of deps versions

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,5 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
+    <AspNetCoreModuleVersion>1.0.1990</AspNetCoreModuleVersion>
     <BenchmarkDotNetPackageVersion>0.10.3</BenchmarkDotNetPackageVersion>
     <EntityFrameworkPackageVersion>6.1.3</EntityFrameworkPackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>

--- a/build/external-dependencies.props
+++ b/build/external-dependencies.props
@@ -21,6 +21,9 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
+    <ExternalDependency Include="AspNetCoreModule" Version="$(AspNetCoreModuleVersion)" Private="true">
+      <VariableName>AspNetCoreModuleVersion</VariableName>
+    </ExternalDependency>
     <ExternalDependency Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" Private="true" />
     <ExternalDependency Include="EntityFramework" Version="$(EntityFrameworkPackageVersion)" Private="true" />
     <ExternalDependency Include="FSharp.Core" Version="$(FSharpCorePackageVersion)" Private="true" />


### PR DESCRIPTION
Generate additional dependency information for downstream consumption by Windows installer builds.