### PR TITLE
Add .App metapackage to the LZMA

### DIFF
--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -32,7 +32,7 @@
     <PackageArtifact Include="dotnet-watch" Category="shipoob" />
     <PackageArtifact Include="Microsoft.AspNet.Identity.AspNetCoreCompat" Category="noship" />
     <PackageArtifact Include="Microsoft.AspNetCore" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
-    <PackageArtifact Include="Microsoft.AspNetCore.App" Category="ship" />
+    <PackageArtifact Include="Microsoft.AspNetCore.App" Category="ship" LZMA="true" />
     <PackageArtifact Include="Microsoft.AspNetCore.All" Category="ship" LZMA="true" />
     <PackageArtifact Include="Microsoft.AspNetCore.Analyzers" Category="shipoob" />
     <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Category="ship" AppMetapackage="true" AllMetapackage="true"/>


### PR DESCRIPTION
Let's take a closer look at https://github.com/aspnet/Universe/commit/d8f190561432ef9dce5b2fef16349d8ff1a321fd.

Currently Microsoft.AspNetCore.App is missing from the LZMA in preview2 but was there in preview1. There were a few reverts and merges around these changes and we ended up with the wrong set of changes in release/2.1. This is currently breaking VS new template tests run by the vendors.