### PR TITLE
Remove two SignalR MessagePack packages

### DIFF
--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -166,9 +166,7 @@
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client.Core" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Http.Connections.Client" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Client.MsgPack" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.SignalR.Protocols.MsgPack" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.SignalR.MsgPack" Category="ship" />
 
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.SpaServices.Extensions" Category="ship" AppMetapackage="true" AllMetapackage="true"/>


### PR DESCRIPTION
Two SignalR packages related to MessagePack are being removed.

Wait until https://github.com/aspnet/SignalR/pull/1830 is merged before merging this PR.