### PR TITLE
Use PackageVersion to define version of the LineupPackage

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -76,10 +76,10 @@
 
   <Target Name="GetLineupPackageInfo">
     <ItemGroup>
-      <ArtifactInfo Include="$(BuildDir)Internal.AspNetCore.Universe.Lineup.$(Version).nupkg">
+      <ArtifactInfo Include="$(BuildDir)Internal.AspNetCore.Universe.Lineup.$(PackageVersion).nupkg">
         <ArtifactType>NuGetPackage</ArtifactType>
         <PackageId>Internal.AspNetCore.Universe.Lineup</PackageId>
-        <Version>$(Version)</Version>
+        <Version>$(PackageVersion)</Version>
         <Category>noship</Category>
         <IsLineup>true</IsLineup>
       </ArtifactInfo>
@@ -109,7 +109,7 @@
     <PackNuSpec NuSpecPath="$(MSBuildThisFileDirectory)lineups\Internal.AspNetCore.Universe.Lineup.nuspec"
                 DestinationFolder="$(BuildDir)"
                 Overwrite="true"
-                Properties="version=$(Version);dependenciesPropsFile=$(GeneratedPackageVersionPropsPath)">
+                Properties="version=$(PackageVersion);dependenciesPropsFile=$(GeneratedPackageVersionPropsPath)">
       <Output TaskParameter="Packages" ItemName="LineupPackage" />
     </PackNuSpec>
   </Target>


### PR DESCRIPTION
Publish failed because it was looking for `Internal.AspNetCore.Universe.Lineup.2.1.0-preview2-30569+pb-20180405-07.nupkg`, but the actual file name is `Internal.AspNetCore.Universe.Lineup.2.1.0-preview2-30569.nupkg`. Change the variables used because NuGet strips the `+` metadata when producing .nupkg files.