### PR TITLE
Exclude additionalDeps files due to file path conflicts with the 2.0.7 release

### DIFF
--- a/build/RuntimeStore.targets
+++ b/build/RuntimeStore.targets
@@ -191,7 +191,7 @@
       <Output TaskParameter="HostingStartupArtifacts" ItemName="HostingStartupArtifacts" />
     </RepoTasks.ResolveHostingStartupPackages>
 
-    <MSBuild
+    <MSBuild Condition="@(HostingStartupArtifacts->Count()) != 0"
       Projects="$(MSBuildProjectFullPath)"
       Targets="_BuildHostingDeps"
       Properties="HostingStartupPackageName=%(HostingStartupArtifacts.PackageId);HostingStartupPackageVersion=%(HostingStartupArtifacts.Version)" />
@@ -200,7 +200,8 @@
       <DepsFiles Include="$(_DepsOutputDirectory)**\*.deps.json" />
     </ItemGroup>
 
-    <RepoTasks.TrimDeps DepsFiles="@(DepsFiles)" />
+    <RepoTasks.TrimDeps Condition="@(DepsFiles->Count()) != 0"
+      DepsFiles="@(DepsFiles)" />
   </Target>
 
   <Target Name="PackRuntimeStore" DependsOnTargets="_ResolveRuntimeStoreRID">
@@ -228,7 +229,9 @@
       SymbolsDestination="$(_SymbolsZipDirectory)"/>
 
     <!-- Insert deps files -->
-    <Copy SourceFiles="@(DepsFiles)" DestinationFolder="$(_StoreZipDirectory)additionalDeps\%(RecursiveDir)" />
+    <Copy Condition="@(DepsFiles->Count()) != 0"
+      SourceFiles="@(DepsFiles)"
+      DestinationFolder="$(_StoreZipDirectory)additionalDeps\%(RecursiveDir)" />
 
     <ItemGroup>
       <OutputZipFiles Include="$(_StoreZipDirectory)**\*" />

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -10,9 +10,21 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
+    <!--
+      Exclude the additionalDeps files for this hosting startup in the 2.0.8 release.
+      This should be re-enabled the next time Microsoft.NETCore.App is shipped.
+    -->
+    <PackageArtifact Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Metapackage="true" RuntimeStore="true" Category="ship">
+      <HostingStartup>false</HostingStartup>
+      <!-- <HostingStartup>true</HostingStartup> -->
+    </PackageArtifact>
+    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Metapackage="true" RuntimeStore="true" Category="ship">
+      <HostingStartup>false</HostingStartup>
+      <!-- <HostingStartup>true</HostingStartup> -->
+    </PackageArtifact>
+
     <PackageArtifact Include="Microsoft.AspNet.Identity.AspNetCoreCompat" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Antiforgery" Metapackage="true" RuntimeStore="true" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Metapackage="true" RuntimeStore="true" HostingStartup="true" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Abstractions" Metapackage="true" RuntimeStore="true" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Cookies" Metapackage="true" RuntimeStore="true" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authentication.Core" Metapackage="true" RuntimeStore="true" Category="ship" />
@@ -28,7 +40,6 @@
     <PackageArtifact Include="Microsoft.AspNetCore.Authorization.Policy" Metapackage="true" RuntimeStore="true" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Authorization" Metapackage="true" RuntimeStore="true" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureKeyVault.HostingStartup" Category="ship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Metapackage="true" RuntimeStore="true" HostingStartup="true" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Metapackage="true" RuntimeStore="true" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Buffering" Category="noship" />


### PR DESCRIPTION
When we produce a new hosting startup additionalDeps file without a new version of Microsoft.NETCore.App, build currently fails due to a conflict in file path.

> The file '/mnt/work/71ae3284d35ddee4/.w/additionalDeps/Microsoft.AspNetCore.ApplicationInsights.HostingStartup/shared/Microsoft.NETCore.App/2.0.7/Microsoft.AspNetCore.ApplicationInsights.HostingStartup.deps.json' already exists.

This resolves the conflict by skipping inclusion of additionalDeps files in 2.0.8.

FYI @muratg 