### PR TITLE
Build upgradeable installers

### DIFF
--- a/build/SharedFx.props
+++ b/build/SharedFx.props
@@ -39,16 +39,31 @@
 
     <DotnetRuntimePackageName>dotnet-runtime</DotnetRuntimePackageName>
     <DotnetRuntimeInstallerPrefix>$(DotnetRuntimePackageName)-$(MicrosoftNETCoreApp21PackageVersion)</DotnetRuntimeInstallerPrefix>
+    <MicrosoftNETCoreApp21IdVersion>2.1</MicrosoftNETCoreApp21IdVersion>
+    <MicrosoftNETCoreApp21InstallerVersion>$(MicrosoftNETCoreApp21PackageVersion.Split('-')[0])</MicrosoftNETCoreApp21InstallerVersion>
+    <DotnetRuntimeUpgradeableInstallerPrefix>$(DotnetRuntimePackageName)-$(MicrosoftNETCoreApp21IdVersion)</DotnetRuntimeUpgradeableInstallerPrefix>
     <RuntimeArchiveLinkPrefix>$(DotNetAssetRootUrl)Runtime/$(MicrosoftNETCoreApp21PackageVersion)/$(DotnetRuntimeInstallerPrefix)</RuntimeArchiveLinkPrefix>
 
     <SharedFxIntermediateArchiveFilePrefix>$(_SharedFxSourceDir)$(SharedFxIntermediateArchiveBaseName)-$(PackageVersion)</SharedFxIntermediateArchiveFilePrefix>
+
+    <!-- installer versions -->
+    <!-- CLI would take a dependency such as 'aspnetcore-runtime-M.N >= M.N.P'. Here M.N is the InstallerIdVersion and M.N.P is the InstallerPackageVersion -->
+    <InstallerIdVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)</InstallerIdVersion>
+    <InstallerPackageVersion>$(InstallerIdVersion).$(AspNetCorePatchVersion)</InstallerPackageVersion>
+    <!-- Deb installers are versioned as M.N.P~Build following the core-setup convention -->
+    <DebInstallerPackageVersion>$(InstallerPackageVersion)</DebInstallerPackageVersion>
+    <DebInstallerPackageVersion Condition="'$(PackageVersionSuffix)' != ''">$(DebInstallerPackageVersion)~$(PackageVersionSuffix)</DebInstallerPackageVersion>
+    <PackageRevision>1</PackageRevision>
+    <!-- While the revision number of Debian installers must stay at 1, the RPM installers will include the build number in the revision if available -->
+    <RpmPackageRevision>$(PackageRevision)</RpmPackageRevision>
+    <RpmPackageRevision Condition="'$(PackageVersionSuffix)' != ''">0.1.$(PackageVersionSuffix)</RpmPackageRevision>
+    <RpmPackageRevision>$([System.String]::Copy('$(RpmPackageRevision)').Replace('-', '_'))</RpmPackageRevision>
 
     <!-- installer metadata -->
     <MaintainerName>Microsoft</MaintainerName>
     <MaintainerEmail>nugetaspnet@microsoft.com</MaintainerEmail>
     <Homepage>https://www.asp.net/</Homepage>
     <InstallRoot>/usr/share/dotnet</InstallRoot>
-    <PackageRevision>1</PackageRevision>
     <LicenseType>Apache-2.0</LicenseType>
     <SharedFxSummary>Microsoft ASP.NET Core $(PackageVersion) Shared Framework</SharedFxSummary>
     <SharedFxDescription>Shared Framework for hosting of Microsoft ASP.NET Core applications. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/aspnet/home). We happily accept issues and PRs.</SharedFxDescription>

--- a/build/SharedFxInstaller.targets
+++ b/build/SharedFxInstaller.targets
@@ -101,14 +101,18 @@
       <ChangeLogProps>DATE=$([System.DateTime]::UtcNow.ToString(ddd MMM dd yyyy))</ChangeLogProps>
       <ChangeLogProps>$(ChangeLogProps);MAINTAINER_NAME=$(RpmMaintainerName)</ChangeLogProps>
       <ChangeLogProps>$(ChangeLogProps);MAINTAINER_EMAIL=$(RpmMaintainerEmail)</ChangeLogProps>
-      <ChangeLogProps>$(ChangeLogProps);PACKAGE_VERSION=$(RpmVersion)</ChangeLogProps>
+      <ChangeLogProps>$(ChangeLogProps);PACKAGE_VERSION=$(RpmPackageVersion)</ChangeLogProps>
       <ChangeLogProps>$(ChangeLogProps);PACKAGE_REVISION=$(RpmRevision)</ChangeLogProps>
     </PropertyGroup>
 
     <GenerateFileFromTemplate TemplateFile="$(_PackagingDir)changelog.in" OutputPath="$(_WorkRoot)templates/changelog" Properties="$(ChangeLogProps)" />
 
     <!-- Run fpm -->
-    <Exec Command="docker run
+    <!-- Retry added due to fpm/docker race where .w/package_root directory cannot be resolved -->
+    <Run
+      FileName="docker"
+      Command="
+      run
       --rm
       -v $(RepositoryRoot):$(_DockerRootDir)
       docker-image-$(Image)
@@ -116,9 +120,9 @@
         --verbose
         -s dir
         -t rpm
-        -n $(RpmInstallerPrefix)-$(RpmVersion)
-        -p $(_DockerRootDir)artifacts/installers/$(RpmInstallerPrefix)-$(RpmVersion)-$(RpmFileSuffix)
-        -v $(RpmVersion)
+        -n $(RpmName)-$(RpmIdVersion)
+        -p $(_DockerRootDir)artifacts/installers/$(RpmName)-$(RpmFileVersion)-$(RpmFileSuffix)
+        -v $(RpmPackageVersion)
         --iteration $(RpmRevision)
         -a amd64
         $(RpmArguments)
@@ -129,7 +133,8 @@
         --vendor &quot;$(RpmVendor)&quot;
         --license &quot;$(RpmLicense)&quot;
         --url &quot;$(RpmHomepage)&quot;
-        $(_DockerRootDir).w/package_root/=&quot;$(RpmInstallRoot)/&quot;" />
+        $(_DockerRootDir).w/package_root/=&quot;$(RpmInstallRoot)/&quot;"
+      MaxRetries="5"/>
   </Target>
 
   <Target Name="GenerateRpms" DependsOnTargets="_EnsureInstallerPrerequisites">
@@ -143,31 +148,45 @@
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_BuildDockerImage" Properties="Image=$(Image)" />
 
     <ItemGroup>
-      <RpmSharedFxDependencies Include="$(DotnetRuntimeInstallerPrefix)" Version="$(MicrosoftNETCoreApp21PackageVersion)" />
+      <RpmNonUpgradeableSharedFxDependencies Include="$(DotnetRuntimeInstallerPrefix)" Version="$(MicrosoftNETCoreApp21PackageVersion)" />
+      <RpmSharedFxDependencies Include="$(DotnetRuntimeUpgradeableInstallerPrefix)" Version="$(MicrosoftNETCoreApp21InstallerVersion)" />
       <RpmRHSharedFxDirectories Include="$(RHInstallRoot)/shared" />
       <RpmGenericSharedFxDirectories Include="$(InstallRoot)/shared" />
     </ItemGroup>
 
     <PropertyGroup>
+      <RpmNonUpgradeableSharedFxArguments>@(RpmNonUpgradeableSharedFxDependencies->' -d &quot;%(Identity) &gt;= %(Version)&quot;', ' ')</RpmNonUpgradeableSharedFxArguments>
       <RpmSharedFxArguments>@(RpmSharedFxDependencies->' -d &quot;%(Identity) &gt;= %(Version)&quot;', ' ')</RpmSharedFxArguments>
+      <RpmNonUpgradeableRHSharedFxArguments>$(RpmNonUpgradeableSharedFxArguments) @(RpmRHSharedFxDirectories->' --directories &quot;%(FullPath)&quot;', ' ')</RpmNonUpgradeableRHSharedFxArguments>
+      <RpmNonUpgradeableGenericSharedFxArguments>$(RpmNonUpgradeableSharedFxArguments) @(RpmGenericSharedFxDirectories->' --directories &quot;%(FullPath)&quot;', ' ')</RpmNonUpgradeableGenericSharedFxArguments>
       <RpmRHSharedFxArguments>$(RpmSharedFxArguments) @(RpmRHSharedFxDirectories->' --directories &quot;%(FullPath)&quot;', ' ')</RpmRHSharedFxArguments>
       <RpmGenericSharedFxArguments>$(RpmSharedFxArguments) @(RpmGenericSharedFxDirectories->' --directories &quot;%(FullPath)&quot;', ' ')</RpmGenericSharedFxArguments>
 
-      <RpmCommonArguments>Image=$(Image);RpmVendor=$(RpmVendor);RpmVersion=$(PackageVersion)</RpmCommonArguments>
-      <RpmCommonArguments>$(RpmCommonArguments);RpmMaintainerName=$(MaintainerName);RpmMaintainerEmail=$(MaintainerEmail)</RpmCommonArguments>
-      <RpmCommonArguments>$(RpmCommonArguments);RpmHomepage=$(Homepage);RpmRevision=$(PackageRevision)</RpmCommonArguments>
-      <RpmCommonArguments>$(RpmCommonArguments);RpmLicense=$(LicenseType)</RpmCommonArguments>
-      <RpmCommonArguments>$(RpmCommonArguments);RpmInstallerPrefix=$(SharedFxInstallerName);SharedFxArchive=$(SharedFxIntermediateArchiveFilePrefix)-linux-x64.tar.gz</RpmCommonArguments>
-      <RpmCommonArguments>$(RpmCommonArguments);RpmMSummary=$(SharedFxSummary);RpmDescription=$(SharedFxDescription)</RpmCommonArguments>
-      <RpmCommonGenericArguments>RpmFileSuffix=x64.rpm;RpmInstallRoot=$(InstallRoot)</RpmCommonGenericArguments>
-      <RpmCommonRHArguments>RpmFileSuffix=rh.rhel.7-x64.rpm;RpmInstallRoot=$(RHInstallRoot)</RpmCommonRHArguments>
+      <RpmCommonProps>Image=$(Image);RpmVendor=$(RpmVendor);RpmName=$(SharedFxInstallerName)</RpmCommonProps>
+      <RpmCommonProps>$(RpmCommonProps);RpmMaintainerName=$(MaintainerName);RpmMaintainerEmail=$(MaintainerEmail)</RpmCommonProps>
+      <RpmCommonProps>$(RpmCommonProps);RpmHomepage=$(Homepage);RpmRevision=$(RpmPackageRevision)</RpmCommonProps>
+      <RpmCommonProps>$(RpmCommonProps);RpmLicense=$(LicenseType)</RpmCommonProps>
+      <RpmCommonProps>$(RpmCommonProps);SharedFxArchive=$(SharedFxIntermediateArchiveFilePrefix)-linux-x64.tar.gz</RpmCommonProps>
+      <RpmCommonProps>$(RpmCommonProps);RpmMSummary=$(SharedFxSummary);RpmDescription=$(SharedFxDescription)</RpmCommonProps>
+      <RpmGenericProps>RpmInstallRoot=$(InstallRoot)</RpmGenericProps>
+      <RpmRHProps>RpmInstallRoot=$(RHInstallRoot)</RpmRHProps>
+      <RpmNonUpgradeableProps>RpmIdVersion=$(PackageVersion);RpmPackageVersion=$(PackageVersion);RpmFileVersion=$(PackageVersion)</RpmNonUpgradeableProps>
+      <RpmProps>RpmIdVersion=$(InstallerIdVersion);RpmPackageVersion=$(InstallerPackageVersion);RpmFileVersion=$(PackageVersion);RpmUpgradeableSuffix=-upgradeable</RpmProps>
 
-      <RpmSharedFxProps>$(RpmCommonArguments);$(RpmCommonGenericArguments);RpmArguments=$(RpmGenericSharedFxArguments)</RpmSharedFxProps>
-      <RpmRHSharedFxProps>$(RpmCommonArguments);$(RpmCommonRHArguments);RpmArguments=$(RpmRHSharedFxArguments)</RpmRHSharedFxProps>
+      <RpmNonUpgradeableSharedFxProps>$(RpmCommonProps);$(RpmGenericProps);$(RpmNonUpgradeableProps);RpmArguments=$(RpmNonUpgradeableGenericSharedFxArguments);RpmFileSuffix=x64.rpm</RpmNonUpgradeableSharedFxProps>
+      <RpmNonUpgradeableRHSharedFxProps>$(RpmCommonProps);$(RpmRHProps);$(RpmNonUpgradeableProps);RpmArguments=$(RpmNonUpgradeableRHSharedFxArguments);RpmFileSuffix=rh.rhel.7-x64.rpm</RpmNonUpgradeableRHSharedFxProps>
+      <RpmSharedFxProps>$(RpmCommonProps);$(RpmGenericProps);$(RpmProps);RpmArguments=$(RpmGenericSharedFxArguments);RpmFileSuffix=x64-upgrade.rpm</RpmSharedFxProps>
+      <RpmRHSharedFxProps>$(RpmCommonProps);$(RpmRHProps);$(RpmProps);RpmArguments=$(RpmRHSharedFxArguments);RpmFileSuffix=rh.rhel.7-x64-upgrade.rpm</RpmRHSharedFxProps>
     </PropertyGroup>
+
+    <!-- NonUpgradeable Generic installer-->
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GenerateRpm" Properties="$(RpmNonUpgradeableSharedFxProps)" />
 
     <!-- Generic installer-->
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GenerateRpm" Properties="$(RpmSharedFxProps)" />
+
+    <!-- NonUpgradeable RH installer-->
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GenerateRpm" Properties="$(RpmNonUpgradeableRHSharedFxProps)" />
 
     <!-- RH installer-->
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GenerateRpm" Properties="$(RpmRHSharedFxProps)" />
@@ -217,8 +236,8 @@
       --rm
       -v $(RepositoryRoot):$(_DockerRootDir)
       -e DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
-      -e INSTALLER_NAME=$(DebPrefix)-$(DebVersion)
-      -e INSTALLER_VERSION=$(DebVersion)
+      -e INSTALLER_NAME=$(DebPrefix)-$(DebIdVersion)
+      -e INSTALLER_VERSION=$(DebPackageVersion)
       docker-image-$(Image)
       ./build.sh /t:RunDebTool"
       ContinueOnError="WarnAndContinue" />
@@ -231,36 +250,46 @@
     <Error Text="@(GeneratedDebFiles->Count()) deb installer files generated." Condition="'@(GeneratedDebFiles->Count())' != 1" />
 
     <Copy
-      DestinationFiles="$(_InstallersOutputDir)$(DebPrefix)-$(DebVersion)-x64.deb"
+      DestinationFiles="$(_InstallersOutputDir)$(DebPrefix)-$(DebFileVersion)-x64$(DebUpgradeSuffix).deb"
       SourceFiles="@(GeneratedDebFiles)"
       OverwriteReadOnlyFiles="True"
       SkipUnchangedFiles="False"
       UseHardlinksIfPossible="False" />
   </Target>
 
-  <Target Name="_GenerateDebOnPlatform">
-    <!-- Build Docker Image -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_BuildDockerImage" Properties="Image=$(Image)" />
+  <Target Name="GenerateDebs" DependsOnTargets="_EnsureInstallerPrerequisites">
+    <PropertyGroup>
+      <NETCoreApp21DebVersion>$(MicrosoftNETCoreApp21PackageVersion)</NETCoreApp21DebVersion>
+      <!-- Needed some creativity to convert the PackageVersion M.N.P-Build to the installer version M.N.P~Build, The conditional handles stabilized builds -->
+      <NETCoreApp21DebVersion Condition="$(NETCoreApp21DebVersion.Contains('-'))">$(NETCoreApp21DebVersion.Substring(0, $(NETCoreApp21DebVersion.IndexOf('-'))))~$(NETCoreApp21DebVersion.Substring($([MSBuild]::Add($(NETCoreApp21DebVersion.IndexOf('-')), 1))))</NETCoreApp21DebVersion>
+    </PropertyGroup>
 
     <ItemGroup>
-      <_DebSharedFxDependencies Include="$(DotnetRuntimeInstallerPrefix)"/>
+      <_DebNonUpgradeableSharedFxDependencies Include="$(DotnetRuntimeInstallerPrefix)"/>
+      <_DebSharedFxDependencies Include="$(DotnetRuntimeUpgradeableInstallerPrefix)" Version="$(NETCoreApp21DebVersion)"/>
     </ItemGroup>
 
     <PropertyGroup>
-      <DebSharedFxDependencies>@(_DebSharedFxDependencies->'"%(Identity)": {}', ', ')</DebSharedFxDependencies>
+      <Image>ubuntu.14.04</Image>
 
-      <CommonProps>Image=$(Image);DebVersion=$(PackageVersion)</CommonProps>
-      <DebSharedFxProps>DebPrefix=$(SharedFxInstallerName);DebSummary=$(SharedFxSummary);DebDescription=$(SharedFxDescription)</DebSharedFxProps>
-      <DebSharedFxProps>$(DebSharedFxProps);DebDependencies=$(DebSharedFxDependencies);SharedFxArchive=$(SharedFxIntermediateArchiveFilePrefix)-linux-x64.tar.gz</DebSharedFxProps>
+      <DebNonUpgradeableSharedFxDependencies>@(_DebNonUpgradeableSharedFxDependencies->'"%(Identity)": { }', ', ')</DebNonUpgradeableSharedFxDependencies>
+      <DebSharedFxDependencies>@(_DebSharedFxDependencies->'"%(Identity)": { "package_version": "%(Version)" }', ', ')</DebSharedFxDependencies>
+
+      <DebCommonProps>Image=$(Image);DebPrefix=$(SharedFxInstallerName)</DebCommonProps>
+      <DebCommonProps>$(DebCommonProps);DebSummary=$(SharedFxSummary);DebDescription=$(SharedFxDescription)</DebCommonProps>
+      <DebCommonProps>$(DebCommonProps);SharedFxArchive=$(SharedFxIntermediateArchiveFilePrefix)-linux-x64.tar.gz</DebCommonProps>
+
+      <DebNonUpgradeableProps>DebIdVersion=$(PackageVersion);DebPackageVersion=$(PackageVersion);DebFileVersion=$(PackageVersion);DebDependencies=$(DebNonUpgradeableSharedFxDependencies)</DebNonUpgradeableProps>
+      <DebProps>DebIdVersion=$(InstallerIdVersion);DebPackageVersion=$(DebInstallerPackageVersion);DebFileVersion=$(PackageVersion);DebDependencies=$(DebSharedFxDependencies);DebUpgradeSuffix=-upgrade</DebProps>
     </PropertyGroup>
 
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GenerateDeb" Properties="$(CommonProps);$(DebSharedFxProps)" />
+    <!-- Build Docker Image -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_BuildDockerImage" Properties="Image=$(Image)" />
+
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GenerateDeb" Properties="$(DebCommonProps);$(DebNonUpgradeableProps)" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GenerateDeb" Properties="$(DebCommonProps);$(DebProps)" />
 
     <!-- Remove Docker Image to save disk space -->
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_RemoveDockerImage" Properties="Image=$(Image)" />
-  </Target>
-
-  <Target Name="GenerateDebs" DependsOnTargets="_EnsureInstallerPrerequisites">
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_GenerateDebOnPlatform" Properties="PackageVersion=$(PackageVersion);Image=ubuntu.14.04" />
   </Target>
 </Project>

--- a/build/repo.props
+++ b/build/repo.props
@@ -36,6 +36,9 @@
     <NativeInstaller Include="x64" FileExt=".deb" />
     <NativeInstaller Include="x64" FileExt=".rpm" />
     <NativeInstaller Include="rh.rhel.7-x64" FileExt=".rpm" />
+    <NativeInstaller Include="x64-upgrade" FileExt=".deb" />
+    <NativeInstaller Include="x64-upgrade" FileExt=".rpm" />
+    <NativeInstaller Include="rh.rhel.7-x64-upgrade" FileExt=".rpm" />
 
     <SharedFrameworkName Include="Microsoft.AspNetCore.All" />
     <SharedFrameworkName Include="Microsoft.AspNetCore.App" />

--- a/version.props
+++ b/version.props
@@ -1,22 +1,26 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.1.0</VersionPrefix>
-    <VersionSuffix>rtm</VersionSuffix>
+    <AspNetCoreMajorVersion>2</AspNetCoreMajorVersion>
+    <AspNetCoreMinorVersion>1</AspNetCoreMinorVersion>
+    <AspNetCorePatchVersion>0</AspNetCorePatchVersion>
+    <VersionPrefix>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion)</VersionPrefix>
+    <PrereleaseVersionLabel>rtm</PrereleaseVersionLabel>
 
     <ExperimentalVersionPrefix>0.1.0</ExperimentalVersionPrefix>
     <ExperimentalVersionSuffix>rtm</ExperimentalVersionSuffix>
 
+    <PackageVersionSuffix Condition=" '$(IsFinalBuild)' != 'true' AND '$(PrereleaseVersionLabel)' != '' ">$(PrereleaseVersionLabel)</PackageVersionSuffix>
+    <PackageVersionSuffix Condition=" '$(IsFinalBuild)' != 'true' AND '$(BuildNumber)' != '' ">$(PackageVersionSuffix)-$(BuildNumber)</PackageVersionSuffix>
+    <PackageVersionSuffix Condition=" '$(IsFinalBuild)' == 'true' AND '$(PrereleaseVersionLabel)' != 'rtm' ">$(PrereleaseVersionLabel)-final</PackageVersionSuffix>
+    <!-- NB: VersionSuffix is empty if '$(IsFinalBuild)' == 'true' AND '$(PrereleaseVersionLabel)' == 'rtm' -->
 
-    <PackageVersion Condition=" '$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
-    <PackageVersion Condition=" '$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
-
-    <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
-
-    <PackageVersion Condition=" '$(IsFinalBuild)' != 'true' ">$(VersionPrefix)</PackageVersion>
-    <PackageVersion Condition=" '$(IsFinalBuild)' != 'true' AND '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
+    <PackageVersion>$(VersionPrefix)</PackageVersion>
+    <PackageVersion Condition=" '$(PackageVersionSuffix)' != '' ">$(VersionPrefix)-$(PackageVersionSuffix)</PackageVersion>
 
     <!-- Add metadata to the suffix last so it does not appear in package versions. -->
     <VersionMetadata Condition=" '$(DotNetProductBuildId)' != '' ">pb-$(DotNetProductBuildId)</VersionMetadata>
+    <VersionSuffix>$(PrereleaseVersionLabel)</VersionSuffix>
+    <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(VersionMetadata)' != '' ">$(VersionSuffix)+$(VersionMetadata)</VersionSuffix>
 
     <ExperimentalPackageVersion Condition=" '$(IsFinalBuild)' == 'true' AND '$(ExperimentalVersionSuffix)' == 'rtm' ">$(ExperimentalVersionPrefix)</ExperimentalPackageVersion>


### PR DESCRIPTION
Addresses #1116 

Now produces these new upgradeable installers with the same naming scheme as https://github.com/dotnet/core-setup/pull/4020/:
- aspnetcore-runtime-2.1.0-rtm-12345-x64-upgrade.deb
- aspnetcore-runtime-2.1.0-rtm-12345-x64-upgrade.rpm
- aspnetcore-runtime-2.1.0-rtm-12345-rh.rhel.7-x64-upgrade.rpm

Note that I'm temporarily continuing to produce the non-upgradeable installers as well. This allows CLI builds to continue working while they react to our changes and switch to producing upgradeable installers.

Testing
- [x] upgradeable installers can be installed along with the upgradeable core-setup dependencies
- [x] upgradeable installers will replace previous versions. For example 2.1.1 will remove the files installed with 2.1.0 and replace them with new 2.1.1 files.
- [x] Ensure stabilized installers are built with the correct versions.