### PR TITLE
Allow targetting of netcoreapp2.2 for sharedfx and lzma

### DIFF
--- a/build/tools/templates/Archive/Archive.csproj
+++ b/build/tools/templates/Archive/Archive.csproj
@@ -7,6 +7,9 @@
     <EnableApiCheck>false</EnableApiCheck>
     <RestoreSources>$(RestoreSources);$(DotNetRestoreSources);</RestoreSources>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+
+    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
+    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>
 
 </Project>

--- a/build/tools/templates/SharedFx/SharedFx.csproj
+++ b/build/tools/templates/SharedFx/SharedFx.csproj
@@ -7,6 +7,9 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <RestoreSources>$(RestoreSources);$(DotNetRestoreSources);</RestoreSources>
+
+    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
+    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Should fix the sharedfx builds.