### PR TITLE
Ensure no trailing slashes for LZMA generation

### DIFF
--- a/build/tasks/CreateLzma.cs
+++ b/build/tasks/CreateLzma.cs
@@ -25,8 +25,9 @@ namespace RepoTasks
                 {
                     if (Directory.Exists(source))
                     {
-                        Log.LogMessage(MessageImportance.High, $"Adding directory: {source}");
-                        archive.AddDirectory(source, progress);
+                        var trimmedSource = source.TrimEnd(new char[] { '\\', '/' });
+                        Log.LogMessage(MessageImportance.High, $"Adding directory: {trimmedSource}");
+                        archive.AddDirectory(trimmedSource, progress);
                     }
                     else
                     {


### PR DESCRIPTION
To be doubly sure the LZMA generated doesn't have missing characters, we can trim trailing slashes in our build tasks as well. This should unblock 2.1.3 prodcon builds and needs to go into release/2.2 and master as well.