### PR TITLE
Remove aspnet/WebHooks from release/2.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -186,7 +186,3 @@
 	path = modules/WebSockets
 	url = https://github.com/aspnet/WebSockets.git
 	branch = release/2.2
-[submodule "modules/WebHooks"]
-	path = modules/WebHooks
-	url = https://github.com/aspnet/WebHooks.git
-	branch = release/2.2

--- a/build/artifacts.props
+++ b/build/artifacts.props
@@ -179,23 +179,6 @@
     <PackageArtifact Include="Microsoft.AspNetCore.TestHost" Category="ship" />
     <PackageArtifact Include="Microsoft.AspNetCore.Testing" Category="noship" />
 
-    <!-- WebHooks packages are not currently shipping, alone or in a meta-package. -->
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.AzureContainerRegistry" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.BitBucket" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.Dropbox" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.Kudu" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.MailChimp" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.Pusher" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.Salesforce" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.Slack" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.Stripe" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.Trello" Category="noship" />
-    <PackageArtifact Include="Microsoft.AspNetCore.WebHooks.Receivers.WordPress" Category="noship" />
-
     <PackageArtifact Include="Microsoft.AspNetCore.WebSockets" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.AspNetCore.WebUtilities" Category="ship" AppMetapackage="true" AllMetapackage="true"/>
     <PackageArtifact Include="Microsoft.CodeAnalysis.Razor" Category="ship" AppMetapackage="true" AllMetapackage="true"/>

--- a/build/buildorder.props
+++ b/build/buildorder.props
@@ -41,7 +41,6 @@
     <RepositoryBuildOrder Include="Identity" Order="15" />
     <RepositoryBuildOrder Include="JavaScriptServices" Order="15" />
     <RepositoryBuildOrder Include="MvcPrecompilation" Order="15" />
-    <RepositoryBuildOrder Include="WebHooks" Order="15" />
     <RepositoryBuildOrder Include="Scaffolding" Order="15" />
     <RepositoryBuildOrder Include="AzureIntegration" Order="15" />
     <RepositoryBuildOrder Include="MusicStore" Order="16" />

--- a/build/submodules.props
+++ b/build/submodules.props
@@ -51,7 +51,6 @@
     <Repository Include="Session" />
     <Repository Include="SignalR" />
     <Repository Include="StaticFiles" />
-    <Repository Include="WebHooks" />
     <Repository Include="WebSockets" />
   </ItemGroup>
 </Project>

--- a/modules/SubmoduleGraph.dgml
+++ b/modules/SubmoduleGraph.dgml
@@ -46,7 +46,6 @@
     <Node Id="Session" Label="Session" />
     <Node Id="SignalR" Label="SignalR" />
     <Node Id="StaticFiles" Label="StaticFiles" />
-    <Node Id="WebHooks" Label="WebHooks" />
     <Node Id="WebSockets" Label="WebSockets" />
   </Nodes>
   <Links>
@@ -380,12 +379,6 @@
     <Link Source="StaticFiles" Target="IISIntegration" />
     <Link Source="StaticFiles" Target="KestrelHttpServer" />
     <Link Source="StaticFiles" Target="Logging" />
-    <Link Source="WebHooks" Target="Common" />
-    <Link Source="WebHooks" Target="Configuration" />
-    <Link Source="WebHooks" Target="Logging" />
-    <Link Source="WebHooks" Target="MetaPackages" />
-    <Link Source="WebHooks" Target="Mvc" />
-    <Link Source="WebHooks" Target="StaticFiles" />
     <Link Source="WebSockets" Target="Common" />
     <Link Source="WebSockets" Target="Configuration" />
     <Link Source="WebSockets" Target="Diagnostics" />


### PR DESCRIPTION
Per email thread, we'll keep WebHooks building in master, but we'll remove it for now from 2.2. We can re-add later as we nail down the shipping schedule.